### PR TITLE
Fix compiler warnings

### DIFF
--- a/pg_documentdb/src/aggregation/bson_densify.c
+++ b/pg_documentdb/src/aggregation/bson_densify.c
@@ -294,6 +294,11 @@ Datum
 bson_densify_range(PG_FUNCTION_ARGS)
 {
 	pgbson *result = DensifyPartitionCore(fcinfo, DENSIFY_TYPE_RANGE);
+	if (result == NULL)
+	{
+		PG_RETURN_NULL();
+	}
+
 	PG_RETURN_POINTER(result);
 }
 
@@ -318,6 +323,11 @@ Datum
 bson_densify_partition(PG_FUNCTION_ARGS)
 {
 	pgbson *result = DensifyPartitionCore(fcinfo, DENSIFY_TYPE_PARTITION);
+	if (result == NULL)
+	{
+		PG_RETURN_NULL();
+	}
+
 	PG_RETURN_POINTER(result);
 }
 
@@ -792,7 +802,7 @@ DensifyPartitionCore(PG_FUNCTION_ARGS, DensifyType type)
 			 *     - Empty collection.
 			 *     - Filtered collection with 0 rows.
 			 */
-			PG_RETURN_NULL();
+			return NULL;
 		}
 	}
 	else

--- a/pg_documentdb/src/aggregation/bson_project.c
+++ b/pg_documentdb/src/aggregation/bson_project.c
@@ -1148,7 +1148,7 @@ static void
 BuildRedactState(BsonReplaceRootRedactState *redactState, const bson_value_t *redactValue,
 				 pgbson *variableSpec)
 {
-	ParseAggregationExpressionContext context = { allowRedactVariables: true };
+	ParseAggregationExpressionContext context = { .allowRedactVariables = true };
 	redactState->expressionData = palloc0(sizeof(AggregationExpressionData));
 	ParseAggregationExpressionData(redactState->expressionData, redactValue, &context);
 
@@ -1211,7 +1211,7 @@ EvaluateRedactDocument(pgbson *document, const BsonReplaceRootRedactState *state
 	PgbsonToSinglePgbsonElement(evaluatedResult, &evaluatedResultElement);
 
 	AggregationExpressionData *parsedValue = palloc0(sizeof(AggregationExpressionData));
-	ParseAggregationExpressionContext context = { allowRedactVariables: true };
+	ParseAggregationExpressionContext context = { .allowRedactVariables = true };
 	ParseAggregationExpressionData(parsedValue, &evaluatedResultElement.bsonValue,
 								   &context);
 	if (parsedValue->kind == AggregationExpressionKind_SystemVariable)


### PR DESCRIPTION
was getting some compiler warnings from clang (used when compiling PG with --with-llvm):

```
src/aggregation/bson_project.c:1151:48: warning: use of GNU old-style field designator extension [-Wgnu-designator]                                                                           
        ParseAggregationExpressionContext context = { allowRedactVariables: true };                                                                                                           
                                                      ^~~~~~~~~~~~~~~~~~~~~                

rc/aggregation/bson_densify.c:795:4: warning: expression which evaluates to zero treated as a null pointer constant of type 'pgbson *' [-Wnon-literal-null-conversion]                       
                        PG_RETURN_NULL();                                                                                                                                                     
                        ^~~~~~~~~~~~~~~~      
```