### PR TITLE
Fix markdown in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,24 +4,28 @@ about: Create a report to help us improve
 title: ''
 labels: bug, new
 assignees: ''
-
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
+
 **Environment**
 - Operating system and version
 - PostgreSQL version
 - Architecture
 
 **Reproduction Steps**
+
 Steps to reproduce the behavior:
 A code snipped or accessible repository that can reproduce the issue.
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
-** Actual behavior **
+**Actual behavior**
 
 **Additional context**
+
 Add any other context about the problem here.


### PR DESCRIPTION
GitHub requires newlines and no spaces around `**`.

Before:
![CleanShot 2025-01-27 at 11 50 19@2x](https://github.com/user-attachments/assets/cc6e2f6e-9e63-42b4-8328-c829deed2977)

After:
![CleanShot 2025-01-27 at 11 50 46@2x](https://github.com/user-attachments/assets/aa1a8c4a-0965-4d8a-9b52-b996dba69723)
