### PR TITLE
Fix error message about missing shared_preload_libraries in pg_documentdb_core.c

### DIFF
--- a/pg_documentdb_core/src/pg_documentdb_core.c
+++ b/pg_documentdb_core/src/pg_documentdb_core.c
@@ -34,7 +34,7 @@ _PG_init(void)
 	if (!process_shared_preload_libraries_in_progress)
 	{
 		ereport(ERROR, (errmsg(
-							"pg_documentdb_core can only be loaded via shared_preload_libraries"
+							"pg_documentdb_core can only be loaded via shared_preload_libraries. "
 							"Add pg_documentdb_core to shared_preload_libraries configuration "
 							"variable in postgresql.conf.")));
 	}


### PR DESCRIPTION
Error text string is missing period and space.