### PR TITLE
Fix PostgreSQL 17 Building Failure by Hiding query->mergeUseOuterJoin 

### DIFF
--- a/pg_documentdb/src/aggregation/bson_aggregation_output_pipeline.c
+++ b/pg_documentdb/src/aggregation/bson_aggregation_output_pipeline.c
@@ -1272,7 +1272,9 @@ AddTargetCollectionRTEDollarMerge(Query *query, MongoCollection *targetCollectio
 	RangeTblEntry *existingrte = list_nth(query->rtable, 0);
 	query->rtable = list_make2(rte, existingrte);
 	query->resultRelation = 1;
+	#if PG_VERSION_NUM < 170000
 	query->mergeUseOuterJoin = true;
+	#endif
 	query->targetList = NIL;
 }
 


### PR DESCRIPTION
Related Issue: https://github.com/microsoft/documentdb/issues/73

`query->mergeUseOuterJoin` is removed in postgres 17

- [PG16: https://github.com/postgres/postgres/blob/REL_16_8/src/include/nodes/parsenodes.h#L186](https://github.com/postgres/postgres/blob/REL_16_8/src/include/nodes/parsenodes.h#L186)
- [PG17: https://github.com/postgres/postgres/blob/REL_17_4/src/include/nodes/parsenodes.h#L186](https://github.com/postgres/postgres/blob/REL_17_4/src/include/nodes/parsenodes.h#L186)

The following marco fix the build issue against PostgreSQL 17

```c
	#if PG_VERSION_NUM < 170000
	query->mergeUseOuterJoin = true;
	#endif
```

You may have to replace it with the PG 17 new fields in the future.

```c
	int  mergeTargetRelation pg_node_attr(query_jumble_ignore);

	/* join condition between source and target for MERGE */
	Node *mergeJoinCondition;
```

But for now, at least it can pass the building process for PG 17.