### PR TITLE
Update regress_tests.yml to remove ubuntu-20.04

### DIFF
--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -31,8 +31,8 @@ jobs:
           - 15
           - 16
         os_name:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -32,7 +32,7 @@ jobs:
           - 16
         os_name:
           - ubuntu-22.04
-          - ubuntu-latest
+          - ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -46,10 +46,6 @@ jobs:
           export LANGUAGE=en_US
           export LC_COLLATE=en_US.UTF-8
           export LC_CTYPE=en_US.UTF-8
-
-          # Create the file repository configuration:
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 16" > /etc/apt/sources.list.d/pgdg.list'
-          curl -4sSf https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | sudo bash
 
           # Import the repository signing key:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -32,7 +32,6 @@ jobs:
           - 16
         os_name:
           - ubuntu-22.04
-          - ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -32,7 +32,7 @@ jobs:
           - 16
         os_name:
           - ubuntu-22.04
-          - ubuntu-24.04
+          - ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Some dependencies does not support ubuntu-24.04(noble) yet, remove 20.04 and add 24.04 later

Resolves #72 