### PR TITLE
Update OSS sync pipeline

### DIFF
--- a/.pipelines/documentdb-oss-sync.yml
+++ b/.pipelines/documentdb-oss-sync.yml
@@ -2,6 +2,9 @@ trigger:
   branches:
     include:
       - "*"
+  paths:
+    exclude:
+      - ".github/*"
   batch: true
 
 pool:


### PR DESCRIPTION
Add exclude paths to the OSS sync pipeline trigger to exclude the `.github` directory from the pipeline trigger.