### PR TITLE
Fix timezone string corruption caused by stack lifetime.

### DIFF
--- a/pg_documentdb/src/operators/bson_expression_date_operators.c
+++ b/pg_documentdb/src/operators/bson_expression_date_operators.c
@@ -6938,7 +6938,7 @@ ValidateOffsetMinutes(char *dateString, int sizeOfDateString, int *indexOfDateSt
 	int hours = totalMins / 60;
 	int minutes = totalMins % 60;
 
-	char hoursAndMinsFmt[7];
+	char *hoursAndMinsFmt = (char *) palloc0(7 * sizeof(char));
 	sprintf(hoursAndMinsFmt, "%c%02d:%02d", sign, hours, minutes);
 
 	dateFromParts->timezone.value_type = BSON_TYPE_UTF8;
@@ -7061,7 +7061,7 @@ ValidateTimezoneOffsetForDateString(char *dateString, int sizeOfDateString,
 			 (dateString[*indexOfDateStringIter] == '-'))
 	{
 		/* for +0530 or -05:30 max len is 6 and 1 for '/0' */
-		char timezoneOffset[7];
+		char *timezoneOffset = (char *) palloc0(7 * sizeof(char));
 		int timezoneOffsetLen = 0;
 
 		/* Copying the sign */


### PR DESCRIPTION
**Describe the bug**

bson_expression_date_operators.c:6941

![Image](https://github.com/user-attachments/assets/118e7e2e-77bd-4e41-930d-d8196d02bbfa)

bson_expression_date_operators.c:7064

![Image](https://github.com/user-attachments/assets/a6ed0de4-6479-4a7d-a5d7-236e9e623d49)

In these two places, the code allocates string space on the stack and assigns it to dateFromParts->timezone later: 
![Image](https://github.com/user-attachments/assets/7e16c264-fb7b-40c4-96a1-4aab50f375f4)



**Environment**
- Linux
- PostgreSQL 16
- Architecture

**Reproduction Steps**

compilation: gcc -fstack-protector-strong -O0
run test case: bson_aggregation_date_operators_tests

```PostgreSQL
postgres=# select * from bson_dollar_project('{}','{"result": {"$dateFromString": {"dateString": "2021-01-11T12:53:12.506+130", "format": "%Y-%m-%dT%H:%M:%S.%L%Z"} } }');
ERROR:  unrecognized time zone identifier: "t���"
```

**Solution**

Maybe using palloc0 is reasonable instead of allocating string on stack.

