### PR TITLE
Fix use validator on stack after returning.

### DIFF
--- a/pg_documentdb/src/commands/create_collection_view.c
+++ b/pg_documentdb/src/commands/create_collection_view.c
@@ -378,8 +378,10 @@ ParseCreateSpec(Datum databaseDatum, pgbson *createSpec, bool *hasSchemaValidati
 		}
 		else if (strcmp(key, "validator") == 0)
 		{
-			spec->validator = ParseAndGetValidatorSpec(&createIter, "create.validator",
-													   hasSchemaValidationSpec);
+			bson_value_t *validator = palloc0(sizeof(bson_value_t));
+			*validator = *(ParseAndGetValidatorSpec(&createIter, "create.validator",
+													hasSchemaValidationSpec));
+			spec->validator = validator;
 		}
 		else if (strcmp(key, "validationLevel") == 0)
 		{


### PR DESCRIPTION
**Describe the bug**

pg_documentdb/src/metadata/collection.c:1905, the function ParseAndGetValidatorSpec returns a variable 'validator' allocated on stack.
```c
//...
	EnsureTopLevelFieldType(validatorName, iter, BSON_TYPE_DOCUMENT);
	const bson_value_t *validator = bson_iter_value(iter);

	/* Large and overly complex validation rules can impact database performance, especially during write operations. */
	if (validator->value.v_doc.data_len > (uint32_t) MaxSchemaValidatorSize)
//...
```


pg_documentdb/src/commands/create_collection_view.c:382, the function ParseCreateSpec assign the pointer to spec->validator, which will be used after the function returning.

```c
else if (strcmp(key, "validator") == 0)
{
	spec->validator = ParseAndGetValidatorSpec(&createIter, "create.validator",
										   hasSchemaValidationSpec);
}
```


**Environment**
- Linux
- PostgreSQL 16
- Architecture

**Reproduction Steps**

compilation: gcc -fstack-protector-strong -O0
run test case: schema_validation_insert, schema_validation

```PostgreSQL
postgres=# SELECT documentdb_api.create_collection_view('schema_validation', '{ "create": "col", "validator": {"$jsonSchema": {"bsonType": "object", "properties": {"a": {"bsonType": "int"}}}}, "validationLevel": "strict", "validationAction": "error"}');
NOTICE:  creating collection
ERROR:  expected a document to create a bson object
```

**Solution**

Use palloc0.
