### PR TITLE
[Test] fix: use normalized expected files in test cases

### DIFF
--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_stage_densify.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_stage_densify.out
@@ -687,7 +687,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 54_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 8
@@ -697,24 +697,24 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
                      Node: host=localhost port=58070 dbname=regression
                      ->  Seq Scan on documentdb_data.documents_4770_477016 collection
                            Output: document
-   ->  Distributed Subplan 54_2
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 1
                Tasks Shown: All
                ->  Task
-                     Query: SELECT intermediate_result.document FROM read_intermediate_result('54_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson) UNION ALL SELECT NULL::documentdb_core.bson AS document
+                     Query: SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson) UNION ALL SELECT NULL::documentdb_core.bson AS document
                      Node: host=localhost port=58070 dbname=regression
                      ->  Append
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: intermediate_result.document
-                                 Function Call: read_intermediate_result('54_1'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            ->  Result
                                  Output: NULL::documentdb_core.bson
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT documentdb_api_internal.bson_densify_range(agg_stage_0_1.document, '{ "field" : "cost", "partitionByFields" : [ "a" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (PARTITION BY (documentdb_api_internal.bson_expression_partition_by_fields_get(agg_stage_0_1.document, '{ "" : [ "a" ] }'::documentdb_core.bson)) ORDER BY (documentdb_api_catalog.bson_orderby(agg_stage_0_1.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('54_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0_1) agg_stage_0
+         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT documentdb_api_internal.bson_densify_range(agg_stage_0_1.document, '{ "field" : "cost", "partitionByFields" : [ "a" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (PARTITION BY (documentdb_api_internal.bson_expression_partition_by_fields_get(agg_stage_0_1.document, '{ "" : [ "a" ] }'::documentdb_core.bson)) ORDER BY (documentdb_api_catalog.bson_orderby(agg_stage_0_1.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0_1) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  ProjectSet
                Output: documentdb_api_catalog.bson_lookup_unwind((documentdb_api_internal.bson_densify_range(intermediate_result.document, '{ "field" : "cost", "partitionByFields" : [ "a" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (?)), '_'::text)
@@ -725,7 +725,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
                            Sort Key: (documentdb_api_internal.bson_expression_partition_by_fields_get(intermediate_result.document, '{ "" : [ "a" ] }'::documentdb_core.bson)), (documentdb_api_catalog.bson_orderby(intermediate_result.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: documentdb_api_catalog.bson_orderby(intermediate_result.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson), documentdb_api_internal.bson_expression_partition_by_fields_get(intermediate_result.document, '{ "" : [ "a" ] }'::documentdb_core.bson), intermediate_result.document
-                                 Function Call: read_intermediate_result('54_2'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (41 rows)
 
 EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('db',
@@ -756,7 +756,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 59_1
+   ->  Distributed Subplan X_X
          ->  WindowAgg
                Output: bson_densify_full(remote_scan.document, '{ "field" : "cost", "partitionByFields" : [ "a" ], "range" : { "bounds" : "full", "step" : { "$numberInt" : "1" } } }'::bson) OVER (?), remote_scan.worker_column_2
                ->  Sort
@@ -774,13 +774,13 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('59_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  ProjectSet
                Output: documentdb_api_catalog.bson_lookup_unwind(intermediate_result.document, '_'::text)
                ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                      Output: intermediate_result.document
-                     Function Call: read_intermediate_result('59_1'::text, 'binary'::citus_copy_format)
+                     Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (27 rows)
 
 -- Reshard multikey
@@ -1035,7 +1035,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 80_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 8
@@ -1045,24 +1045,24 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
                      Node: host=localhost port=58070 dbname=regression
                      ->  Seq Scan on documentdb_data.documents_4770_477024 collection
                            Output: document
-   ->  Distributed Subplan 80_2
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 1
                Tasks Shown: All
                ->  Task
-                     Query: SELECT intermediate_result.document FROM read_intermediate_result('80_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson) UNION ALL SELECT NULL::documentdb_core.bson AS document
+                     Query: SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson) UNION ALL SELECT NULL::documentdb_core.bson AS document
                      Node: host=localhost port=58070 dbname=regression
                      ->  Append
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: intermediate_result.document
-                                 Function Call: read_intermediate_result('80_1'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            ->  Result
                                  Output: NULL::documentdb_core.bson
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT documentdb_api_internal.bson_densify_range(agg_stage_0_1.document, '{ "field" : "cost", "partitionByFields" : [ "a", "quantity" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (PARTITION BY (documentdb_api_internal.bson_expression_partition_by_fields_get(agg_stage_0_1.document, '{ "" : [ "a", "quantity" ] }'::documentdb_core.bson)) ORDER BY (documentdb_api_catalog.bson_orderby(agg_stage_0_1.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('80_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0_1) agg_stage_0
+         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT documentdb_api_internal.bson_densify_range(agg_stage_0_1.document, '{ "field" : "cost", "partitionByFields" : [ "a", "quantity" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (PARTITION BY (documentdb_api_internal.bson_expression_partition_by_fields_get(agg_stage_0_1.document, '{ "" : [ "a", "quantity" ] }'::documentdb_core.bson)) ORDER BY (documentdb_api_catalog.bson_orderby(agg_stage_0_1.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0_1) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  ProjectSet
                Output: documentdb_api_catalog.bson_lookup_unwind((documentdb_api_internal.bson_densify_range(intermediate_result.document, '{ "field" : "cost", "partitionByFields" : [ "a", "quantity" ], "range" : { "bounds" : [ { "$numberInt" : "8" }, { "$numberInt" : "12" } ], "step" : { "$numberInt" : "1" } } }'::documentdb_core.bson) OVER (?)), '_'::text)
@@ -1073,7 +1073,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
                            Sort Key: (documentdb_api_internal.bson_expression_partition_by_fields_get(intermediate_result.document, '{ "" : [ "a", "quantity" ] }'::documentdb_core.bson)), (documentdb_api_catalog.bson_orderby(intermediate_result.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson)) NULLS FIRST
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: documentdb_api_catalog.bson_orderby(intermediate_result.document, '{ "cost" : { "$numberLong" : "1" } }'::documentdb_core.bson), documentdb_api_internal.bson_expression_partition_by_fields_get(intermediate_result.document, '{ "" : [ "a", "quantity" ] }'::documentdb_core.bson), intermediate_result.document
-                                 Function Call: read_intermediate_result('80_2'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (41 rows)
 
 EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('db',
@@ -1104,7 +1104,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 84_1
+   ->  Distributed Subplan X_X
          ->  WindowAgg
                Output: bson_densify_full(remote_scan.document, '{ "field" : "cost", "partitionByFields" : [ "a", "quantity" ], "range" : { "bounds" : "full", "step" : { "$numberInt" : "1" } } }'::bson) OVER (?), remote_scan.worker_column_2
                ->  Sort
@@ -1122,13 +1122,13 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('84_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_catalog.bson_lookup_unwind(document, '_'::text) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  ProjectSet
                Output: documentdb_api_catalog.bson_lookup_unwind(intermediate_result.document, '_'::text)
                ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                      Output: intermediate_result.document
-                     Function Call: read_intermediate_result('84_1'::text, 'binary'::citus_copy_format)
+                     Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (27 rows)
 
 -- Test that internal number of documents generated limits are working

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_stage_setWindowFields.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_stage_setWindowFields.out
@@ -348,7 +348,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM documentdb_api_catalog.bson
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 78_1
+   ->  Distributed Subplan X_X
          ->  WindowAgg
                Output: remote_scan.document, bsonsum(documentdb_api_internal.bson_expression_get(remote_scan.total, '{ "" : { "$numberInt" : "1" } }'::documentdb_core.bson, true, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)) OVER (?), remote_scan."?partitionBy?"
                ->  Sort
@@ -366,11 +366,11 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM documentdb_api_catalog.bson
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(document, documentdb_core.bson_repath_and_build('total'::text, total)) AS document FROM (SELECT intermediate_result.document, intermediate_result.total FROM read_intermediate_result('78_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, total documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(document, documentdb_core.bson_repath_and_build('total'::text, total)) AS document FROM (SELECT intermediate_result.document, intermediate_result.total FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, total documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result.document, documentdb_core.bson_repath_and_build('total'::text, intermediate_result.total))
-               Function Call: read_intermediate_result('78_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (25 rows)
 
 SELECT document FROM documentdb_api_catalog.bson_aggregation_pipeline('db',
@@ -441,7 +441,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM documentdb_api_catalog.bson
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 97_1
+   ->  Distributed Subplan X_X
          ->  WindowAgg
                Output: remote_scan.document, bsonsum(documentdb_api_internal.bson_expression_get(remote_scan.total, '{ "" : { "$numberInt" : "1" } }'::documentdb_core.bson, true, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)) OVER (?), remote_scan."?partitionBy?"
                ->  Sort
@@ -459,11 +459,11 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM documentdb_api_catalog.bson
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(document, documentdb_core.bson_repath_and_build('total'::text, total)) AS document FROM (SELECT intermediate_result.document, intermediate_result.total FROM read_intermediate_result('97_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, total documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(document, documentdb_core.bson_repath_and_build('total'::text, total)) AS document FROM (SELECT intermediate_result.document, intermediate_result.total FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, total documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result.document, documentdb_core.bson_repath_and_build('total'::text, intermediate_result.total))
-               Function Call: read_intermediate_result('97_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (25 rows)
 
 ---------------------------------------------------------------------

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_let.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_let.out
@@ -1050,10 +1050,10 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 409_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan."left", remote_scan."right", remote_scan.let
-               ->  Distributed Subplan 412_1
+               ->  Distributed Subplan X_X
                      ->  Custom Scan (Citus Adaptive)
                            Output: remote_scan.document, remote_scan.let
                            Task Count: 2
@@ -1068,7 +1068,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
                                  Node: host=localhost port=58070 dbname=regression
                                  ->  Seq Scan on documentdb_data.documents_4140_413233 collection
                                        Output: document, documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)
-               ->  Distributed Subplan 412_2
+               ->  Distributed Subplan X_X
                      ->  Custom Scan (Citus Adaptive)
                            Output: remote_scan.document
                            Task Count: 1
@@ -1084,27 +1084,27 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
                Task Count: 1
                Tasks Shown: All
                ->  Task
-                     Query: SELECT lookup_stage_1.document AS "left", "lookupRight_stage_1".document AS "right", documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(lookup_stage_1.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson) AS let FROM ((SELECT intermediate_result.document, intermediate_result.let FROM read_intermediate_result('412_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, let documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('412_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_expr(lookup_right_query_stage_0.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, lookup_stage_1.let)) "lookupRight_stage_1" ON (true))
+                     Query: SELECT lookup_stage_1.document AS "left", "lookupRight_stage_1".document AS "right", documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(lookup_stage_1.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson) AS let FROM ((SELECT intermediate_result.document, intermediate_result.let FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, let documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_expr(lookup_right_query_stage_0.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, lookup_stage_1.let)) "lookupRight_stage_1" ON (true))
                      Node: host=localhost port=58070 dbname=regression
                      ->  Nested Loop Left Join
                            Output: intermediate_result.document, (COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)), documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(intermediate_result.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: intermediate_result.document, intermediate_result.let
-                                 Function Call: read_intermediate_result('412_1'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            ->  Aggregate
                                  Output: COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)
                                  ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                                        Output: intermediate_result_1.document
-                                       Function Call: read_intermediate_result('412_2'::text, 'binary'::citus_copy_format)
+                                       Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                                        Filter: documentdb_api_internal.bson_dollar_expr(intermediate_result_1.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, intermediate_result.let)
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents("left", (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, lookup_non_inlined_stage_1.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS "funcName" FROM documentdb_api_catalog.bson_lookup_unwind(lookup_non_inlined_stage_1."right", 'myMatch'::text) lookup_subpipeline_substage_0(lookup_unwind))) AS document FROM (SELECT intermediate_result."left", intermediate_result."right", intermediate_result.let FROM read_intermediate_result('409_1'::text, 'binary'::citus_copy_format) intermediate_result("left" documentdb_core.bson, "right" documentdb_core.bson, let documentdb_core.bson)) lookup_non_inlined_stage_1
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents("left", (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, lookup_non_inlined_stage_1.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS "funcName" FROM documentdb_api_catalog.bson_lookup_unwind(lookup_non_inlined_stage_1."right", 'myMatch'::text) lookup_subpipeline_substage_0(lookup_unwind))) AS document FROM (SELECT intermediate_result."left", intermediate_result."right", intermediate_result.let FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result("left" documentdb_core.bson, "right" documentdb_core.bson, let documentdb_core.bson)) lookup_non_inlined_stage_1
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result."left", (SubPlan 1))
-               Function Call: read_intermediate_result('409_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                SubPlan 1
                  ->  Aggregate
                        Output: COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, intermediate_result.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)
@@ -1133,10 +1133,10 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 437_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan."left", remote_scan."right", remote_scan.let
-               ->  Distributed Subplan 440_1
+               ->  Distributed Subplan X_X
                      ->  Custom Scan (Citus Adaptive)
                            Output: remote_scan.document, remote_scan.let
                            Task Count: 2
@@ -1151,7 +1151,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
                                  Node: host=localhost port=58070 dbname=regression
                                  ->  Seq Scan on documentdb_data.documents_4140_413233 collection
                                        Output: document, documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)
-               ->  Distributed Subplan 440_2
+               ->  Distributed Subplan X_X
                      ->  Custom Scan (Citus Adaptive)
                            Output: remote_scan.document
                            Task Count: 2
@@ -1169,27 +1169,27 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document from bson_aggregation_pipeline('
                Task Count: 1
                Tasks Shown: All
                ->  Task
-                     Query: SELECT lookup_stage_1.document AS "left", "lookupRight_stage_1".document AS "right", documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(lookup_stage_1.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson) AS let FROM ((SELECT intermediate_result.document, intermediate_result.let FROM read_intermediate_result('440_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, let documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('440_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_expr(lookup_right_query_stage_0.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, lookup_stage_1.let)) "lookupRight_stage_1" ON (true))
+                     Query: SELECT lookup_stage_1.document AS "left", "lookupRight_stage_1".document AS "right", documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(lookup_stage_1.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson) AS let FROM ((SELECT intermediate_result.document, intermediate_result.let FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, let documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_expr(lookup_right_query_stage_0.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, lookup_stage_1.let)) "lookupRight_stage_1" ON (true))
                      Node: host=localhost port=58070 dbname=regression
                      ->  Nested Loop Left Join
                            Output: intermediate_result.document, (COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)), documentdb_api_internal.bson_dollar_lookup_expression_eval_merge(intermediate_result.document, '{ "item_name" : "$item" }'::documentdb_core.bson, '{ "now" : NOW_SYS_VARIABLE }'::documentdb_core.bson)
                            ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                                  Output: intermediate_result.document, intermediate_result.let
-                                 Function Call: read_intermediate_result('440_1'::text, 'binary'::citus_copy_format)
+                                 Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            ->  Aggregate
                                  Output: COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)
                                  ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                                        Output: intermediate_result_1.document
-                                       Function Call: read_intermediate_result('440_2'::text, 'binary'::citus_copy_format)
+                                       Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                                        Filter: documentdb_api_internal.bson_dollar_expr(intermediate_result_1.document, '{ "" : { "$eq" : [ "$name", "$$item_name" ] } }'::documentdb_core.bson, intermediate_result.let)
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents("left", (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, lookup_non_inlined_stage_1.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS "funcName" FROM documentdb_api_catalog.bson_lookup_unwind(lookup_non_inlined_stage_1."right", 'myMatch'::text) lookup_subpipeline_substage_0(lookup_unwind))) AS document FROM (SELECT intermediate_result."left", intermediate_result."right", intermediate_result.let FROM read_intermediate_result('437_1'::text, 'binary'::citus_copy_format) intermediate_result("left" documentdb_core.bson, "right" documentdb_core.bson, let documentdb_core.bson)) lookup_non_inlined_stage_1
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents("left", (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, lookup_non_inlined_stage_1.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson) AS "funcName" FROM documentdb_api_catalog.bson_lookup_unwind(lookup_non_inlined_stage_1."right", 'myMatch'::text) lookup_subpipeline_substage_0(lookup_unwind))) AS document FROM (SELECT intermediate_result."left", intermediate_result."right", intermediate_result.let FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result("left" documentdb_core.bson, "right" documentdb_core.bson, let documentdb_core.bson)) lookup_non_inlined_stage_1
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result."left", (SubPlan 1))
-               Function Call: read_intermediate_result('437_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                SubPlan 1
                  ->  Aggregate
                        Output: COALESCE(documentdb_api_catalog.bson_array_agg(documentdb_api_internal.bson_dollar_project(lookup_subpipeline_substage_0.lookup_unwind, '{ "c" : { "$numberInt" : "0" } }'::documentdb_core.bson, intermediate_result.let), 'myMatch'::text), '{ "myMatch" : [  ] }'::documentdb_core.bson)

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_maxnminn_group.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_maxnminn_group.out
@@ -507,7 +507,7 @@ EXPLAIN (COSTS OFF) SELECT document FROM bson_aggregation_pipeline('db', '{ "agg
                                                                                                                 QUERY PLAN                                                                                                                 
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
-   ->  Distributed Subplan 142_1
+   ->  Distributed Subplan X_X
          ->  HashAggregate
                Group Key: remote_scan.c2
                ->  Custom Scan (Citus Adaptive)
@@ -529,7 +529,7 @@ EXPLAIN (COSTS OFF) SELECT document FROM bson_aggregation_pipeline('db', '{ "agg
                                                                                                                 QUERY PLAN                                                                                                                 
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
-   ->  Distributed Subplan 144_1
+   ->  Distributed Subplan X_X
          ->  HashAggregate
                Group Key: remote_scan.c2
                ->  Custom Scan (Citus Adaptive)

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_hnsw.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_hnsw.out
@@ -3012,7 +3012,7 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 1981_1
+   ->  Distributed Subplan X_X
          ->  Limit
                Output: remote_scan.document, remote_scan."?sort?"
                ->  Sort
@@ -3036,11 +3036,11 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, public.l2_distance(public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true), public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.9000000000000003553" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "efSearch" : { "$numberInt" : "1" }, "exact" : true }'::documentdb_core.bson, 'vector'::text), 3, true))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('1981_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, public.l2_distance(public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true), public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.9000000000000003553" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "efSearch" : { "$numberInt" : "1" }, "exact" : true }'::documentdb_core.bson, 'vector'::text), 3, true))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_document_add_score_field(intermediate_result.document, l2_distance(vector(documentdb_api_internal.bson_extract_vector(intermediate_result.document, 'v'::text), 3, true), '[3,4.9,1]'::vector))
-               Function Call: read_intermediate_result('1981_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (31 rows)
 
 COMMIT;

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_ivf.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_ivf.out
@@ -3183,7 +3183,7 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 1740_1
+   ->  Distributed Subplan X_X
          ->  Limit
                Output: remote_scan.document, remote_scan."?sort?"
                ->  Sort
@@ -3207,11 +3207,11 @@ EXPLAIN (VERBOSE on, COSTS off) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, public.l2_distance(public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true), public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.9000000000000003553" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "nProbes" : { "$numberInt" : "1" }, "exact" : true }'::documentdb_core.bson, 'vector'::text), 3, true))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('1740_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, public.l2_distance(public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true), public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.9000000000000003553" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "nProbes" : { "$numberInt" : "1" }, "exact" : true }'::documentdb_core.bson, 'vector'::text), 3, true))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_document_add_score_field(intermediate_result.document, l2_distance(vector(documentdb_api_internal.bson_extract_vector(intermediate_result.document, 'v'::text), 3, true), '[3,4.9,1]'::vector))
-               Function Call: read_intermediate_result('1740_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (31 rows)
 
 COMMIT;

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_mongo.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_aggregation_pipeline_tests_vector_mongo.out
@@ -98,7 +98,7 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 188_1
+   ->  Distributed Subplan X_X
          ->  Limit
                Output: remote_scan.document, remote_scan."?sort?"
                ->  Sort
@@ -123,11 +123,11 @@ EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, ('1'::double precision OPERATOR(pg_catalog.-) (public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true) OPERATOR(public.<=>) public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.0" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "efSearch" : { "$numberInt" : "100" } }'::documentdb_core.bson, 'vector'::text), 3, true)))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('188_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
+         Query: SELECT documentdb_api_internal.bson_document_add_score_field(document, ('1'::double precision OPERATOR(pg_catalog.-) (public.vector(documentdb_api_internal.bson_extract_vector(document, 'v'::text), 3, true) OPERATOR(public.<=>) public.vector(documentdb_api_internal.bson_extract_vector('{ "vector" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "4.0" }, { "$numberDouble" : "1.0" } ], "k" : { "$numberInt" : "2" }, "path" : "v", "efSearch" : { "$numberInt" : "100" } }'::documentdb_core.bson, 'vector'::text), 3, true)))) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) agg_stage_0
          Node: host=localhost port=58070 dbname=regression
          ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                Output: documentdb_api_internal.bson_document_add_score_field(intermediate_result.document, ('1'::double precision - (vector(documentdb_api_internal.bson_extract_vector(intermediate_result.document, 'v'::text), 3, true) <=> '[3,4,1]'::vector)))
-               Function Call: read_intermediate_result('188_1'::text, 'binary'::citus_copy_format)
+               Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
 (32 rows)
 
 ROLLBACK;

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/bson_dollar_ops_collation_tests_runtime.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/bson_dollar_ops_collation_tests_runtime.out
@@ -1750,7 +1750,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 337_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document, remote_scan.lookup_filter
                Task Count: 8
@@ -1760,7 +1760,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
                      Node: host=localhost port=58070 dbname=regression
                      ->  Seq Scan on documentdb_data.documents_7995_7990168 collection
                            Output: document, documentdb_api_internal.bson_dollar_lookup_extract_filter_expression(document, '{ "_id" : "_id", "collation" : "en-u-ks-level1" }'::documentdb_core.bson)
-   ->  Distributed Subplan 337_2
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 8
@@ -1774,18 +1774,18 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(lookup_stage_1.document, "lookupRight_stage_1".document) AS document FROM ((SELECT intermediate_result.document, intermediate_result.lookup_filter FROM read_intermediate_result('337_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, lookup_filter documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('337_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_lookup_join_filter(lookup_right_query_stage_0.document, lookup_stage_1.lookup_filter, '_id'::text)) "lookupRight_stage_1" ON (true))
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(lookup_stage_1.document, "lookupRight_stage_1".document) AS document FROM ((SELECT intermediate_result.document, intermediate_result.lookup_filter FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, lookup_filter documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_lookup_join_filter(lookup_right_query_stage_0.document, lookup_stage_1.lookup_filter, '_id'::text)) "lookupRight_stage_1" ON (true))
          Node: host=localhost port=58070 dbname=regression
          ->  Nested Loop Left Join
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result.document, (COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson)))
                ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                      Output: intermediate_result.document, intermediate_result.lookup_filter
-                     Function Call: read_intermediate_result('337_1'::text, 'binary'::citus_copy_format)
+                     Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                ->  Aggregate
                      Output: COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson)
                      ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                            Output: intermediate_result_1.document
-                           Function Call: read_intermediate_result('337_2'::text, 'binary'::citus_copy_format)
+                           Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            Filter: documentdb_api_internal.bson_dollar_lookup_join_filter(intermediate_result_1.document, intermediate_result.lookup_filter, '_id'::text)
 (39 rows)
 
@@ -1812,7 +1812,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Output: remote_scan.document
-   ->  Distributed Subplan 345_1
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document, remote_scan.lookup_filter
                Task Count: 8
@@ -1822,7 +1822,7 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
                      Node: host=localhost port=58070 dbname=regression
                      ->  Seq Scan on documentdb_data.documents_7995_7990168 collection
                            Output: document, documentdb_api_internal.bson_dollar_lookup_extract_filter_expression(document, '{ "a.b" : "a.b", "collation" : "en-u-ks-level1" }'::documentdb_core.bson)
-   ->  Distributed Subplan 345_2
+   ->  Distributed Subplan X_X
          ->  Custom Scan (Citus Adaptive)
                Output: remote_scan.document
                Task Count: 8
@@ -1836,18 +1836,18 @@ EXPLAIN (VERBOSE ON, COSTS OFF) SELECT document FROM bson_aggregation_pipeline('
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(lookup_stage_1.document, "lookupRight_stage_1".document) AS document FROM ((SELECT intermediate_result.document, intermediate_result.lookup_filter FROM read_intermediate_result('345_1'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, lookup_filter documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('345_2'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_lookup_join_filter(lookup_right_query_stage_0.document, lookup_stage_1.lookup_filter, 'a.b'::text)) "lookupRight_stage_1" ON (true))
+         Query: SELECT documentdb_api_internal.bson_dollar_merge_documents(lookup_stage_1.document, "lookupRight_stage_1".document) AS document FROM ((SELECT intermediate_result.document, intermediate_result.lookup_filter FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson, lookup_filter documentdb_core.bson)) lookup_stage_1 LEFT JOIN LATERAL (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(lookup_right_query_stage_0.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson) AS document FROM (SELECT intermediate_result.document FROM read_intermediate_result('X_X'::text, 'binary'::citus_copy_format) intermediate_result(document documentdb_core.bson)) lookup_right_query_stage_0 WHERE documentdb_api_internal.bson_dollar_lookup_join_filter(lookup_right_query_stage_0.document, lookup_stage_1.lookup_filter, 'a.b'::text)) "lookupRight_stage_1" ON (true))
          Node: host=localhost port=58070 dbname=regression
          ->  Nested Loop Left Join
                Output: documentdb_api_internal.bson_dollar_merge_documents(intermediate_result.document, (COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson)))
                ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                      Output: intermediate_result.document, intermediate_result.lookup_filter
-                     Function Call: read_intermediate_result('345_1'::text, 'binary'::citus_copy_format)
+                     Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                ->  Aggregate
                      Output: COALESCE(documentdb_api_catalog.bson_array_agg(intermediate_result_1.document, 'matched_docs'::text), '{ "matched_docs" : [  ] }'::documentdb_core.bson)
                      ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                            Output: intermediate_result_1.document
-                           Function Call: read_intermediate_result('345_2'::text, 'binary'::citus_copy_format)
+                           Function Call: read_intermediate_result('X_X'::text, 'binary'::citus_copy_format)
                            Filter: documentdb_api_internal.bson_dollar_lookup_join_filter(intermediate_result_1.document, intermediate_result.lookup_filter, 'a.b'::text)
 (39 rows)
 


### PR DESCRIPTION
In distributed scenarios, we should compare the expected file with result files normalized by normalize.sed, but the expected file has some unnormalized content. We fixed this by replace strings like "123_1" to "X_X".