### PR TITLE
Replace deprecated `bson_as_json` with `bson_as_legacy_extended_json`

### DIFF
--- a/pg_documentdb_core/src/io/pgbson.c
+++ b/pg_documentdb_core/src/io/pgbson.c
@@ -449,7 +449,7 @@ PgbsonToLegacyJson(const pgbson *bsonDocument)
 	}
 
 	/* since bson strings are palloced - we can simply return the string created. */
-	return bson_as_json(&bson, NULL);
+	return bson_as_legacy_extended_json(&bson, NULL);
 }
 
 


### PR DESCRIPTION
As `bson_as_json`  is deprecated. Replace it with `bson_as_legacy_extended_json`.