### PR TITLE
Add dockerfile for pre-build image

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_prebuild
+++ b/.github/containers/Build-Ubuntu/Dockerfile_prebuild
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/cosmosdb/ubuntu/documentdb-oss:base
+
+WORKDIR /home/documentdb/code  
+
+COPY . /home/documentdb/code  
+
+RUN git config --global --add safe.directory /home/DocumentDB/code
+RUN make  && sudo make install
+  
+# Set the entry point to run the new script at container startup  
+ENTRYPOINT ["/home/documentdb/code/scripts/start_services.sh"]  

--- a/.github/containers/Build-Ubuntu/Dockerfile_prebuild
+++ b/.github/containers/Build-Ubuntu/Dockerfile_prebuild
@@ -8,4 +8,4 @@ RUN git config --global --add safe.directory /home/DocumentDB/code
 RUN make  && sudo make install
   
 # Set the entry point to run the new script at container startup  
-ENTRYPOINT ["/home/documentdb/code/scripts/start_services.sh"]  
+CMD ["bash", "-c", "/home/documentdb/code/scripts/start_oss_server.sh & tail -f /dev/null"]

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,7 +1,0 @@
-#!/bin/bash  
-  
-# Start the OSS server  
-./scripts/start_oss_server.sh 
-  
-# Start psql and connect to the database  
-psql -p 9712 -d postgres  

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,0 +1,7 @@
+#!/bin/bash  
+  
+# Start the OSS server  
+./scripts/start_oss_server.sh 
+  
+# Start psql and connect to the database  
+psql -p 9712 -d postgres  


### PR DESCRIPTION
Add files for pre-build image and start services script.

- Navigate to the repo and build this image with:
    ```bash
    docker build . -f .\.github\containers\Build-Ubuntu\Dockerfile_prebuild -t <image-tag> 
    ```
- The image is now available for:

    ```bash
    docker pull mcr.microsoft.com/cosmosdb/ubuntu/documentdb-oss:20.04
    ```

- Base image is built from `.github\containers\Build-Ubuntu\Dockerfile`