### PR TITLE
enforce cmake version in sql tests workflow 

### DIFF
--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cmake --version
           sudo apt-get update
-          sudo apt-get install -y cmake=3.31.*
+          sudo apt-get install -y cmake=3.31.6
           cmake --version
 
       - name: Install package dependencies

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cmake --version
           sudo apt-get update
-          sudo apt-get install -y cmake=3.31.6
+          sudo apt-get install -y cmake=3.*
           cmake --version
 
       - name: Install package dependencies
@@ -66,7 +66,6 @@ jobs:
           tzdata \
           build-essential \
           pkg-config \
-          cmake \
           git \
           locales \
           gcc \

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -1,7 +1,7 @@
 name: SQL Tests
 run-name: ${{ github.event.pull_request.title || '' }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: sql-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -36,6 +36,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Install CMake 3.22
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake=3.22.*
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -37,10 +37,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Install CMake 3.22
+      - name: Install CMake
         run: |
+          cmake --version
           sudo apt-get update
-          sudo apt-get install -y cmake=3.22.*
+          sudo apt-get install -y cmake=3.31.*
+          cmake --version
 
       - name: Install package dependencies
         run: |


### PR DESCRIPTION
This is a workaround to quickly fix the cmake version non-compatible error in the regress test workflow.

The citus indent tool is depending on uncrustify, for which we are depending on an old version with cmake_minimum_required set to 2.8.

resolves #137 