### PR TITLE
[#163] Do not set collation for bool types

### DIFF
--- a/pg_documentdb/src/aggregation/bson_aggregation_metadata_queries.c
+++ b/pg_documentdb/src/aggregation/bson_aggregation_metadata_queries.c
@@ -526,7 +526,7 @@ GenerateBaseListCollectionsQuery(Datum databaseDatum, bool nameOnly,
 								 (Expr *) databaseVar,
 								 (Expr *) makeConst(TEXTOID, -1, InvalidOid, -1,
 													databaseDatum, false, false),
-								 DEFAULT_COLLATION_OID, DEFAULT_COLLATION_OID);
+								 InvalidOid, DEFAULT_COLLATION_OID);
 
 	/* Remove system collections */
 	Var *collectionVar = makeVar(1, 2, TEXTOID, -1, InvalidOid, 0);
@@ -535,7 +535,7 @@ GenerateBaseListCollectionsQuery(Datum databaseDatum, bool nameOnly,
 											sentinelCollection.length);
 	Expr *notExpr = make_opclause(TextNotEqualOperatorId(), BOOLOID, false,
 								  (Expr *) collectionVar, (Expr *) systemCollection,
-								  DEFAULT_COLLATION_OID, DEFAULT_COLLATION_OID);
+								  InvalidOid, DEFAULT_COLLATION_OID);
 
 	query->jointree = makeFromExpr(list_make1(rtr), (Node *) make_ands_explicit(
 									   list_make2(opExpr, notExpr)));


### PR DESCRIPTION
The two calls to `make_opclause `with return type `BOOLOID`, have incorrect `DEFAULT_COLLATION_OID` set as the output collation id `opcollid`. Changing this to `InvalidOid` instead.

Fixes #163