### PR TITLE
Fix user id for k8s operator

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -39,6 +39,9 @@ ARG BASE_ARCH=AMD64
 ARG BASE_VERSION=0.103.0
 FROM mcr.microsoft.com/cosmosdb/ubuntu/documentdb-oss:22.04-PG16-${BASE_ARCH}-${BASE_VERSION} AS final
 
+# Set postgres user and group to desired UID/GID
+RUN sudo groupmod -g 103 postgres && sudo usermod -u 105 -g 103 postgres
+
 RUN sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends \
     jq openssl lsof && \
@@ -61,7 +64,8 @@ ENV ENFORCE_SSL="true" \
     START_POSTGRESQL="true" \
     POSTGRESQL_PORT="9712" \
     OWNER="documentdb" \
-    ALLOW_EXTERNAL_CONNECTIONS="false"
+    ALLOW_EXTERNAL_CONNECTIONS="false" \
+    PATH=/usr/lib/postgresql/16/bin:$PATH
 
 RUN sudo mkdir /home/documentdb/gateway
 


### PR DESCRIPTION
This PR fix the issue where CloudNAtive PG failed to start due to user id and group id mismatch.
Also add postgres to the PATH