### PR TITLE
Add OpenTelemetry Monitoring to DocumentDB Gateway (Phase 1)

### DIFF
--- a/pg_documentdb_gw/Cargo.lock
+++ b/pg_documentdb_gw/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -38,6 +38,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arc-swap"
@@ -81,9 +87,9 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -92,9 +98,9 @@ version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -185,10 +191,10 @@ dependencies = [
  "base64 0.13.1",
  "bitvec",
  "hex",
- "indexmap",
+ "indexmap 2.2.6",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -210,9 +216,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cadence"
@@ -399,7 +405,10 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
- "rand",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "rand 0.8.5",
  "rcgen",
  "regex",
  "reqwest",
@@ -588,9 +597,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -656,7 +665,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -683,12 +704,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -759,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -771,9 +798,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -787,6 +814,19 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -807,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -820,7 +860,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -837,12 +876,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -850,6 +899,15 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -932,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1007,7 +1065,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha-1",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1049,7 +1107,7 @@ dependencies = [
  "ntex-service",
  "ntex-util",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1088,7 +1146,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50a359f2a10c712b0446675070c22b1437d57a7cf08139f6a229e1e80817ed84"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1107,7 +1165,7 @@ dependencies = [
  "ntex-service",
  "ntex-tokio",
  "ntex-util",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1300,9 +1358,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1321,6 +1379,86 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+dependencies = [
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -1407,9 +1545,9 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1458,7 +1596,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -1500,11 +1638,34 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.95",
+ "quote 1.0.36",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1522,8 +1683,14 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -1538,8 +1705,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1549,7 +1726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1558,7 +1745,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1627,6 +1823,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1668,7 +1865,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1726,12 +1923,12 @@ checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.65",
+ "syn 2.0.101",
  "unicode-ident",
 ]
 
@@ -1853,9 +2050,9 @@ version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1864,7 +2061,7 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -2005,18 +2202,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -2072,7 +2269,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2081,9 +2287,20 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.36",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2159,9 +2376,9 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2205,11 +2422,22 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2226,6 +2454,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,11 +2487,16 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2269,9 +2528,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2345,7 +2604,7 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -2377,6 +2636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,9 +2669,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -2435,9 +2703,9 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2619,6 +2887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,7 +2928,7 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
- "proc-macro2 1.0.83",
+ "proc-macro2 1.0.95",
  "quote 1.0.36",
- "syn 2.0.65",
+ "syn 2.0.101",
 ]

--- a/pg_documentdb_gw/Cargo.toml
+++ b/pg_documentdb_gw/Cargo.toml
@@ -38,6 +38,11 @@ async-trait = "0.1.88"
 dyn-clone = "1.0.19"
 whoami = "1.6.0"
 
+# OpenTelemetry dependencies
+opentelemetry = { version = "0.29.1", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.29.0", features = ["metrics", "grpc-tonic"] }
+
 [dependencies.simple_logger]
 version = "4.2.0"
 default-features = false

--- a/pg_documentdb_gw/src/context/connection.rs
+++ b/pg_documentdb_gw/src/context/connection.rs
@@ -35,7 +35,7 @@ pub struct ConnectionContext {
     pub requires_response: bool,
     pub client_information: Option<RawDocumentBuf>,
     pub transaction: Option<(Vec<u8>, i64)>,
-    pub telemetry_provider: Option<Box<dyn TelemetryProvider>>,
+    pub telemetry_provider: Option<Arc<dyn TelemetryProvider>>,
     pub ip: SocketAddr,
     pub cipher_type: i32,
     pub ssl_protocol: String,
@@ -120,7 +120,7 @@ impl ConnectionContext {
 
     pub async fn new(
         sc: ServiceContext,
-        telemetry_provider: Option<Box<dyn TelemetryProvider>>,
+        telemetry_provider: Option<Arc<dyn TelemetryProvider>>,
         ip: SocketAddr,
         ssl_protocol: String,
     ) -> Self {

--- a/pg_documentdb_gw/src/lib.rs
+++ b/pg_documentdb_gw/src/lib.rs
@@ -39,17 +39,19 @@ pub mod configuration;
 pub mod context;
 pub mod error;
 pub mod explain;
+pub mod open_telemetry_provider;
 pub mod postgres;
 pub mod processor;
 pub mod protocol;
 pub mod requests;
 pub mod responses;
 pub mod telemetry;
+pub mod monitoring;
 
 pub async fn run_server(
     sc: ServiceContext,
     certificate_options: CertificateOptions,
-    telemetry: Option<Box<dyn TelemetryProvider>>,
+    telemetry: Option<Arc<dyn TelemetryProvider>>,
     token: CancellationToken,
     cipher_map: Option<fn(Option<&str>) -> i32>,
 ) -> Result<()> {
@@ -135,7 +137,7 @@ pub async fn populate_ssl_certificates() -> Result<CertificateOptions> {
 async fn listen_for_connections(
     sc: ServiceContext,
     certificate_options: &CertificateOptions,
-    telemetry: Option<Box<dyn TelemetryProvider>>,
+    telemetry: Option<Arc<dyn TelemetryProvider>>,
     listener: &TcpListener,
     token: CancellationToken,
     enforce_ssl_tcp: bool,
@@ -187,7 +189,7 @@ async fn get_stream(ssl: Ssl, stream: TcpStream) -> Result<SslStream<TcpStream>>
 async fn handle_connection(
     ssl: Ssl,
     sc: ServiceContext,
-    telemetry: Option<Box<dyn TelemetryProvider>>,
+    telemetry: Option<Arc<dyn TelemetryProvider>>,
     ip: SocketAddr,
     stream: TcpStream,
     enforce_ssl_tcp: bool,

--- a/pg_documentdb_gw/src/monitoring/mod.rs
+++ b/pg_documentdb_gw/src/monitoring/mod.rs
@@ -1,0 +1,88 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/monitoring/mod.rs
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::interval;
+use log::{info, warn, error};
+
+use crate::postgres::Pool;
+use crate::telemetry::TelemetryProvider;
+
+/// ClusterMonitor periodically checks the availability of primary and secondary clusters
+/// and emits metrics via the TelemetryProvider.
+pub struct ClusterMonitor {
+    primary_pool: Arc<Pool>,
+    secondary_pool: Option<Arc<Pool>>,
+    telemetry: Arc<dyn TelemetryProvider>,
+    check_interval: Duration,
+}
+
+impl ClusterMonitor {
+    pub fn new(
+        primary_pool: Arc<Pool>,
+        secondary_pool: Option<Arc<Pool>>,
+        telemetry: Arc<dyn TelemetryProvider>,
+        check_interval_secs: u64,
+    ) -> Self {
+        ClusterMonitor {
+            primary_pool,
+            secondary_pool,
+            telemetry,
+            check_interval: Duration::from_secs(check_interval_secs),
+        }
+    }
+
+    /// Start the cluster monitoring background task
+    pub async fn start(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = interval(self.check_interval);
+            
+            loop {
+                interval.tick().await;
+                self.check_cluster_availability().await;
+            }
+        })
+    }
+
+    /// Check the availability of all clusters and emit metrics
+    async fn check_cluster_availability(&self) {
+        // Check primary cluster availability
+        let primary_available = self.check_pool_availability(&self.primary_pool, "primary").await;
+        self.telemetry.update_cluster_availability("primary", primary_available);
+
+        // Check secondary cluster availability if configured
+        if let Some(secondary_pool) = &self.secondary_pool {
+            let secondary_available = self.check_pool_availability(secondary_pool, "secondary").await;
+            self.telemetry.update_cluster_availability("secondary", secondary_available);
+        }
+    }
+
+    /// Check if a specific connection pool is available by attempting to get a connection
+    async fn check_pool_availability(&self, pool: &Pool, cluster_name: &str) -> bool {
+        match pool.get().await {
+            Ok(mut client) => {
+                // Try to execute a simple query to confirm the connection works
+                match client.query("SELECT 1", &[]).await {
+                    Ok(_) => {
+                        info!("{} cluster is available", cluster_name);
+                        true
+                    }
+                    Err(e) => {
+                        warn!("{} cluster query failed: {}", cluster_name, e);
+                        false
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to connect to {} cluster: {}", cluster_name, e);
+                false
+            }
+        }
+    }
+}

--- a/pg_documentdb_gw/src/open_telemetry_provider.rs
+++ b/pg_documentdb_gw/src/open_telemetry_provider.rs
@@ -1,0 +1,116 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/open_telemetry_provider.rs
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use crate::context::ConnectionContext;
+use crate::protocol::header::Header;
+use crate::requests::compute_request_tracker::ComputeRequestTracker;
+use crate::requests::Request;
+use crate::responses::{CommandError, Response};
+use crate::telemetry::TelemetryProvider;
+use async_trait::async_trait;
+use either::Either;
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+use once_cell::sync::OnceCell;
+
+// OpenTelemetry imports
+use opentelemetry::{KeyValue, metrics::MeterProvider};
+use opentelemetry_otlp::{WithExportConfig};
+
+// Global meter provider for OpenTelemetry
+static METER_PROVIDER: OnceCell<Arc<opentelemetry_sdk::metrics::SdkMeterProvider>> = OnceCell::new();
+
+#[derive(Clone)]
+pub struct OpenTelemetryProvider {
+    traffic_counter: opentelemetry::metrics::Counter<u64>,
+    availability_gauge: opentelemetry::metrics::Gauge<i64>,
+}
+
+impl OpenTelemetryProvider {
+    pub fn new() -> Self {
+        // Initialize the global meter provider if not already done
+        let meter_provider = METER_PROVIDER.get_or_init(|| {
+            let endpoint = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+                .unwrap_or_else(|_| "http://otel-collector:4317".to_string());
+            
+            let exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint)
+                .with_timeout(Duration::from_secs(5))
+                .build()
+                .expect("Failed to build OTLP exporter");
+            
+            let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+                .with_periodic_exporter(exporter)
+                .build();
+
+            Arc::new(provider)
+        });
+
+        let meter = meter_provider.meter("documentdb_gateway");
+
+        let traffic_counter = meter
+            .u64_counter("docdb_gateway_request_routing")
+            .with_description("Counts requests routed to primary or secondary regions")
+            .build();
+
+        let availability_gauge = meter
+            .i64_gauge("docdb_cluster_availability")
+            .with_description("Reports perceived availability of database clusters")
+            .build();
+            
+        OpenTelemetryProvider {
+            traffic_counter,
+            availability_gauge,
+        }
+    }
+}
+
+#[async_trait]
+impl TelemetryProvider for OpenTelemetryProvider {
+    async fn emit_request_event(
+        &self,
+        _context: &ConnectionContext,
+        _header: &Header,
+        _request: Option<&Request<'_>>,
+        response: Either<&Response, (&CommandError, usize)>,
+        target_region: String,
+        _request_tracker: &mut ComputeRequestTracker,
+    ) {
+        // Determine if the request succeeded
+        let status = match &response {
+            Either::Left(_) => "success",
+            Either::Right(_) => "failure",
+        };
+        
+        // Track this request being routed to the target region
+        self.track_request_routing(&target_region, status);
+        
+        // Additional metrics could be added here in future phases
+    }
+    
+    fn update_cluster_availability(&self, cluster_id: &str, is_available: bool) {
+        let value = if is_available { 1 } else { 0 };
+        self.availability_gauge.record(
+            value, 
+            &[KeyValue::new("cluster_id", cluster_id.to_string())]
+        );
+    }
+    
+    fn track_request_routing(&self, target_region: &str, status: &str) {
+        // Increment the traffic counter for routing decisions
+        self.traffic_counter.add(
+            1,
+            &[
+                KeyValue::new("target_region", target_region.to_string()),
+                KeyValue::new("status", status.to_string())
+            ]
+        );
+    }
+}

--- a/pg_documentdb_gw/src/telemetry.rs
+++ b/pg_documentdb_gw/src/telemetry.rs
@@ -15,6 +15,9 @@ use async_trait::async_trait;
 use dyn_clone::{clone_trait_object, DynClone};
 use either::Either;
 
+// Re-export the OpenTelemetry provider
+pub use crate::open_telemetry_provider::OpenTelemetryProvider;
+
 // TelemetryProvider takes care of emitting events and metrics
 // for tracking the gateway.
 #[async_trait]
@@ -29,6 +32,12 @@ pub trait TelemetryProvider: Send + Sync + DynClone {
         _: String,
         _: &mut ComputeRequestTracker,
     );
+
+    // Check and emit the perceived availability of a cluster
+    fn update_cluster_availability(&self, cluster_id: &str, is_available: bool);
+    
+    // Track a request being routed to a specific region
+    fn track_request_routing(&self, target_region: &str, status: &str);
 }
 
 clone_trait_object!(TelemetryProvider);


### PR DESCRIPTION
This PR implements Phase 1 of OpenTelemetry instrumentation for the DocumentDB Gateway. The implementation focuses on two critical metrics that provide immediate operational visibility:

### Cluster Availability Tracking
- Adds metrics to monitor the perceived availability of primary and secondary clusters
- Implemented as gauge metrics with `cluster_id` labels
- Values: 1 (available) or 0 (unavailable)

### Request Routing Monitoring
- Tracks traffic routing between primary and secondary regions
- Implemented as counter metrics with `target_region` and `status` labels
- Provides visibility into traffic shifts during failover events

### The PR includes:
- OpenTelemetry provider implementation
- Telemetry trait integration with the gateway
- Docker-based monitoring stack with:
  - OpenTelemetry Collector
  - Prometheus
  - Grafana dashboards
- Documentation on monitoring setup and usage

This implementation creates a foundation for enhanced observability that will help detect and diagnose failover events and cluster availability issues in multi-region deployments.