### PR TITLE
Add prebuild image tasks in GH action

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -1,4 +1,4 @@
-name: Build deb packages
+name: Build deb packages and prebuild images
 concurrency:
   group: build-packages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
-        os: [ubuntu22.04, deb12]
+        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -34,7 +33,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          # - 17
+          - 17
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -100,7 +100,7 @@ jobs:
           push: true
           platforms: linux/${{ matrix.arch }}
           file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
-          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
+          tags: documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             POSTGRES_VERSION=${{ matrix.pg_version }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
-        os: [ubuntu22.04, deb12]
+        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -34,7 +33,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          # - 17
+          - 17
 
     steps:
       - name: Checkout repository
@@ -107,7 +106,7 @@ jobs:
           push: true
           platforms: linux/${{ matrix.arch }}
           file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
-          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ env.DOCUMENTDB_VERSION }}
+          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             POSTGRES_VERSION=${{ matrix.pg_version }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - "main"
     paths-ignore:
-      - '.devcontainer/**'
-      - '*.md'
+      - ".devcontainer/**"
+      - "*.md"
 
 permissions:
   packages: write
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
-        os: [ubuntu22.04, deb12]
+        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -34,7 +33,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          # - 17
+          - 17
 
     steps:
       - name: Checkout repository
@@ -104,7 +103,7 @@ jobs:
           DOCKER_BUILD_SUMMARY: false
         with:
           provenance: false # Disable provenance to avoid unknown/unknown
-          sbom: false       # Disable provenance to avoid unknown/unknown
+          sbom: false # Disable provenance to avoid unknown/unknown
           context: .
           push: true
           platforms: linux/${{ matrix.arch }}
@@ -116,14 +115,16 @@ jobs:
             DEB_PACKAGE_REL_PATH=${{ env.PACKAGE_NAME }}
           labels: |
             org.opencontainers.image.source=https://github.com/microsoft/documentdb
-            org.opencontainers.image.description="Documentdb prebuild build image"
+            org.opencontainers.image.description=Documentdb prebuild image
             org.opencontainers.image.licenses=MIT
 
       - name: Install cosign
         uses: sigstore/cosign-installer@main
+
       - name: Sign manifest (keyless)
         run: |
           cosign sign ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} -y
+      
       - name: Verify manifest signature (keyless)
         run: |
           cosign verify \

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -54,3 +54,32 @@ jobs:
           retention-days: 7
           if-no-files-found: error
           compression-level: 0
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and Push ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.pg_version }} Image
+        run: |
+          case ${{ matrix.os }} in
+              deb11)
+                  DOCKER_IMAGE="debian:bullseye"
+                  ;;
+              deb12)
+                  DOCKER_IMAGE="debian:bookworm"
+                  ;;
+              ubuntu22.04)
+                  DOCKER_IMAGE="ubuntu:22.04"
+                  ;;
+              ubuntu24.04)
+                  DOCKER_IMAGE="ubuntu:24.04"
+                  ;;
+          esac
+          PACKAGE_NAME=$(ls packaging/*.deb)
+          docker build \
+            -t ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} \
+            --platform=linux/${{ matrix.arch }} \
+            --build-arg BASE_IMAGE=$DOCKER_IMAGE \
+            --build-arg POSTGRES_VERSION=${{ matrix.pg_version }} \
+            --build-arg DEB_PACKAGE_REL_PATH=$PACKAGE_NAME \
+            -f .github/containers/Build-Ubuntu/Dockerfile_prebuild .
+          docker push ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Extract image build metadata
         id: image_metadata
         run: |
-          PACKAGE_NAME=$(ls packaging/*.deb)
+          PACKAGE_NAME=$(ls packaging/*.deb | grep -v dbgsym | head -n1)
           echo "PACKAGE NAME: $PACKAGE_NAME"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -93,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: true
           platforms: linux/${{ matrix.arch }}
           file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
           tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        os: [ubuntu22.04, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -33,7 +34,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          - 17
+          # - 17
 
     steps:
       - name: Checkout repository
@@ -98,10 +99,12 @@ jobs:
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.18.0
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
+          provenance: false # Disable provenance to avoid unknown/unknown
+          sbom: false       # Disable provenance to avoid unknown/unknown
           context: .
           push: true
           platforms: linux/${{ matrix.arch }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -107,7 +107,7 @@ jobs:
           push: true
           platforms: linux/${{ matrix.arch }}
           file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
-          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
+          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ env.DOCUMENTDB_VERSION }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             POSTGRES_VERSION=${{ matrix.pg_version }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -57,7 +57,10 @@ jobs:
           compression-level: 0
 
       - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        os: [ubuntu22.04, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -28,7 +29,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          - 17
+          # - 17
 
     steps:
       - name: Checkout repository
@@ -94,6 +95,7 @@ jobs:
           context: .
           push: false
           platforms: linux/${{ matrix.arch }}
+          file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
           tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           push: true
@@ -110,3 +112,7 @@ jobs:
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             POSTGRES_VERSION=${{ matrix.pg_version }}
             DEB_PACKAGE_REL_PATH=${{ env.PACKAGE_NAME }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/microsoft/documentdb
+            org.opencontainers.image.description="Documentdb prebuild build image"
+            org.opencontainers.image.licenses=MIT

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        # os: [ubuntu22.04, ubuntu24.04, deb11, deb12]
+        os: [ubuntu22.04, deb12]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -33,7 +34,7 @@ jobs:
             runner: ubuntu-24.04-arm
         pg_version:
           - 16
-          - 17
+          # - 17
 
     steps:
       - name: Checkout repository
@@ -117,3 +118,15 @@ jobs:
             org.opencontainers.image.source=https://github.com/microsoft/documentdb
             org.opencontainers.image.description="Documentdb prebuild build image"
             org.opencontainers.image.licenses=MIT
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+      - name: Sign manifest (keyless)
+        run: |
+          cosign sign ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} -y
+      - name: Verify manifest signature (keyless)
+        run: |
+          cosign verify \
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/build_packages.yml@refs/heads/${{ github.ref_name }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -58,28 +58,71 @@ jobs:
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build and Push ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.pg_version }} Image
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract image build metadata
+        id: image_metadata
         run: |
+          PACKAGE_NAME=$(ls packaging/*.deb)
+          echo "PACKAGE NAME: $PACKAGE_NAME"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+
           case ${{ matrix.os }} in
               deb11)
-                  DOCKER_IMAGE="debian:bullseye"
+                  BASE_IMAGE="debian:bullseye"
                   ;;
               deb12)
-                  DOCKER_IMAGE="debian:bookworm"
+                  BASE_IMAGE="debian:bookworm"
                   ;;
               ubuntu22.04)
-                  DOCKER_IMAGE="ubuntu:22.04"
+                  BASE_IMAGE="ubuntu:22.04"
                   ;;
               ubuntu24.04)
-                  DOCKER_IMAGE="ubuntu:24.04"
+                  BASE_IMAGE="ubuntu:24.04"
                   ;;
           esac
-          PACKAGE_NAME=$(ls packaging/*.deb)
-          docker build \
-            -t ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} \
-            --platform=linux/${{ matrix.arch }} \
-            --build-arg BASE_IMAGE=$DOCKER_IMAGE \
-            --build-arg POSTGRES_VERSION=${{ matrix.pg_version }} \
-            --build-arg DEB_PACKAGE_REL_PATH=$PACKAGE_NAME \
-            -f .github/containers/Build-Ubuntu/Dockerfile_prebuild .
-          docker push ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
+          echo "BASE_IMAGE NAME: $BASE_IMAGE"
+          echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          platforms: linux/${{ matrix.arch }}
+          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
+          build-args: |
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
+            POSTGRES_VERSION=${{ matrix.pg_version }}
+            DEB_PACKAGE_REL_PATH=${{ env.PACKAGE_NAME }}
+
+      # - name: Build and Push ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.pg_version }} Image
+      #   run: |
+      #     case ${{ matrix.os }} in
+      #         deb11)
+      #             DOCKER_IMAGE="debian:bullseye"
+      #             ;;
+      #         deb12)
+      #             DOCKER_IMAGE="debian:bookworm"
+      #             ;;
+      #         ubuntu22.04)
+      #             DOCKER_IMAGE="ubuntu:22.04"
+      #             ;;
+      #         ubuntu24.04)
+      #             DOCKER_IMAGE="ubuntu:24.04"
+      #             ;;
+      #     esac
+      #     PACKAGE_NAME=$(ls packaging/*.deb)
+
+      #     docker build \
+      #       --platform=linux/${{ matrix.arch }} \
+      #       --build-arg BASE_IMAGE=$DOCKER_IMAGE \
+      #       --build-arg POSTGRES_VERSION=${{ matrix.pg_version }} \
+      #       --build-arg DEB_PACKAGE_REL_PATH=$PACKAGE_NAME \
+      #       -t ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} \
+      #       -f .github/containers/Build-Ubuntu/Dockerfile_prebuild .
+      #     docker push ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -12,6 +12,11 @@ on:
       - '.devcontainer/**'
       - '*.md'
 
+permissions:
+  packages: write
+  contents: read
+  id-token: write
+
 jobs:
   build-deb-packages:
     runs-on: ${{ matrix.runner }}
@@ -100,35 +105,8 @@ jobs:
           push: true
           platforms: linux/${{ matrix.arch }}
           file: .github/containers/Build-Ubuntu/Dockerfile_prebuild
-          tags: documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
+          tags: ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             POSTGRES_VERSION=${{ matrix.pg_version }}
             DEB_PACKAGE_REL_PATH=${{ env.PACKAGE_NAME }}
-
-      # - name: Build and Push ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.pg_version }} Image
-      #   run: |
-      #     case ${{ matrix.os }} in
-      #         deb11)
-      #             DOCKER_IMAGE="debian:bullseye"
-      #             ;;
-      #         deb12)
-      #             DOCKER_IMAGE="debian:bookworm"
-      #             ;;
-      #         ubuntu22.04)
-      #             DOCKER_IMAGE="ubuntu:22.04"
-      #             ;;
-      #         ubuntu24.04)
-      #             DOCKER_IMAGE="ubuntu:24.04"
-      #             ;;
-      #     esac
-      #     PACKAGE_NAME=$(ls packaging/*.deb)
-
-      #     docker build \
-      #       --platform=linux/${{ matrix.arch }} \
-      #       --build-arg BASE_IMAGE=$DOCKER_IMAGE \
-      #       --build-arg POSTGRES_VERSION=${{ matrix.pg_version }} \
-      #       --build-arg DEB_PACKAGE_REL_PATH=$PACKAGE_NAME \
-      #       -t ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }} \
-      #       -f .github/containers/Build-Ubuntu/Dockerfile_prebuild .
-      #     docker push ghcr.io/${{ github.repository }}/documentdb-oss:${{ matrix.os }}-PG${{ matrix.pg_version }}-${{ matrix.arch }}-${{ env.DOCUMENTDB_VERSION }}


### PR DESCRIPTION
Update the GitHub Actions workflow to include tasks for building and pushing prebuild images to the GitHub Container Registry (GHCR).

Sample run: https://github.com/microsoft/documentdb/actions/runs/15432908046
Packages: https://github.com/microsoft/documentdb/pkgs/container/documentdb%2Fdocumentdb-oss