### PR TITLE
Require local auth if external IP is flag is enabled in documentdb-local

### DIFF
--- a/scripts/start_oss_server.sh
+++ b/scripts/start_oss_server.sh
@@ -123,8 +123,8 @@ if [ "$allowExternalAccess" == "true" ]; then
 
   echo "${green}Configuring PostgreSQL to allow access from any IP address${reset}"
   echo "listen_addresses = '*'" >> $postgresConfigFile
-  echo "host all all 0.0.0.0/0 trust" >> $hbaConfigFile
-  echo "host all all ::0/0 trust" >> $hbaConfigFile
+  echo "host all all 0.0.0.0/0 scram-sha-256" >> $hbaConfigFile
+  echo "host all all ::0/0 scram-sha-256" >> $hbaConfigFile
 fi
 
 userName=$(whoami)


### PR DESCRIPTION
If the allowExternalAccess flag is enabled on the Postgres server, this will require to use username password to connect.