### PR TITLE
Rpm percona dependencies

### DIFF
--- a/packaging/rpm_files/documentdb.spec
+++ b/packaging/rpm_files/documentdb.spec
@@ -25,9 +25,9 @@ BuildRequires:  pkg-config
 # BuildRequires:  pcre2-devel
 # BuildRequires: intel-decimal-math-devel # If a devel package exists and is used
 
-Requires:       postgresql%{pg_version}
-Requires:       postgresql%{pg_version}-server
-Requires:       pgvector_%{pg_version}
+Requires:       (postgresql%{pg_version} or percona-postgresql%{pg_version})
+Requires:       (postgresql%{pg_version}-server or percona-postgresql%{pg_version}-server)
+Requires:       (pgvector_%{pg_version} or percona-pgvector%{pg_version})
 Requires:       pg_cron_%{pg_version}
 Requires:       postgis34_%{pg_version}
 Requires:       rum_%{pg_version}

--- a/packaging/rpm_files/documentdb.spec
+++ b/packaging/rpm_files/documentdb.spec
@@ -27,7 +27,7 @@ BuildRequires:  pkg-config
 
 Requires:       (postgresql%{pg_version} or percona-postgresql%{pg_version})
 Requires:       (postgresql%{pg_version}-server or percona-postgresql%{pg_version}-server)
-Requires:       (pgvector_%{pg_version} or percona-pgvector%{pg_version})
+Requires:       (pgvector_%{pg_version} or percona-pgvector_%{pg_version})
 Requires:       pg_cron_%{pg_version}
 Requires:       postgis34_%{pg_version}
 Requires:       rum_%{pg_version}


### PR DESCRIPTION
Allow the rpm of documentb to be installed with the percona version of pgsql as dependencies.