### PR TITLE
Abbreviate SHA hashes to at least 10 characters

### DIFF
--- a/scripts/generate_extension_version.sh
+++ b/scripts/generate_extension_version.sh
@@ -33,7 +33,7 @@ if [ -f $gitIndexDir ]; then
     else
         # set GIT_VERSION with current branch's name and the short sha of the HEAD
         GIT_VERSION=$(git rev-parse --abbrev-ref HEAD)
-        GIT_SHA=$(git rev-parse --short HEAD)
+        GIT_SHA=$(git rev-parse --short=10 HEAD)
     fi
 
     if [[ "$GIT_VERSION" == "" ]] || [[ "$GIT_SHA" == "" ]]; then


### PR DESCRIPTION
That solves a problem with builds of older tags when new commits with the same prefix are added:

```
0.104.0 gitref: HEAD sha:2045d0e buildId:0
0.104.0 gitref: HEAD sha:2045d0e0 buildId:0
```