### PR TITLE
Fix formatting to get past build break

### DIFF
--- a/pg_documentdb_core/src/io/pgbson.c
+++ b/pg_documentdb_core/src/io/pgbson.c
@@ -448,6 +448,7 @@ PgbsonToLegacyJson(const pgbson *bsonDocument)
 
 	/* since bson strings are palloced - we can simply return the string created. */
 #if BSON_CHECK_VERSION(1, 29, 0)
+
 	/*
 	 * bson_as_json is deprecated since mongodb-c-driver 1.29.0
 	 * See: https://www.mongodb.com/community/forums/t/mongodb-c-driver-1-29-0-released/303281


### PR DESCRIPTION
The post-checkin build is broken due to a formatting issue in the pgbson.c file.

Fix up the formatting to be compliant with the build requirements.