### PR TITLE
Add JsonB op class support to documentdb_rum

### DIFF
--- a/internal/pg_documentdb_extended_rum/Makefile
+++ b/internal/pg_documentdb_extended_rum/Makefile
@@ -5,7 +5,7 @@ PGFILEDESC = "DocumentDB Extended RUM index access method"
 
 OSS_SRC_DIR = ../../
 
-SOURCES = $(wildcard src/*.c)
+SOURCES = $(wildcard src/*.c) $(wildcard src/jsonb/*.c)
 OBJS = $(patsubst %.c,%.o,$(SOURCES)) $(WIN32RES)
 
 SQL_DEPDIR=.deps/sql
@@ -40,10 +40,11 @@ override LDFLAGS_SL += -fvisibility=hidden -DHAVE_VISIBILITY_ATTRIBUTE=1
 override CFLAGS += -fvisibility=hidden  -DHAVE_VISIBILITY_ATTRIBUTE=1
 override CXXFLAGS += -fvisibility=hidden  -DHAVE_VISIBILITY_ATTRIBUTE=1
 
+check:
+	$(MAKE) -C src/test all
 
 clean-sql:
 	rm -rf .deps/ build/
-
 
 build-sql: $(generated_sql_files)
 

--- a/internal/pg_documentdb_extended_rum/sql/documentdb_extended_rum--0.107-0--0.108-0.sql
+++ b/internal/pg_documentdb_extended_rum/sql/documentdb_extended_rum--0.107-0--0.108-0.sql
@@ -1,0 +1,10 @@
+
+CREATE SCHEMA documentdb_extended_rum_jsonb_ops;
+CREATE SCHEMA documentdb_extended_rum_jsonb_ops_internal;
+GRANT USAGE ON SCHEMA documentdb_extended_rum_jsonb_ops TO public;
+GRANT USAGE ON SCHEMA documentdb_extended_rum_jsonb_ops_internal to public;
+
+#include "udfs/jsonb/jsonbpath_functions--0.108-0.sql"
+#include "schema/jsonb/jsonbpath_operators--0.108-0.sql"
+#include "udfs/jsonb/jsonbpath_operator_class_functions--0.108-0.sql"
+#include "schema/jsonb/jsonbpath_operator_class--0.108-0.sql"

--- a/internal/pg_documentdb_extended_rum/sql/schema/jsonb/jsonbpath_operator_class--0.108-0.sql
+++ b/internal/pg_documentdb_extended_rum/sql/schema/jsonb/jsonbpath_operator_class--0.108-0.sql
@@ -1,0 +1,14 @@
+CREATE OPERATOR CLASS documentdb_extended_rum_jsonb_ops.jsonb_path_extended_rum_ops
+    DEFAULT FOR TYPE jsonb using documentdb_extended_rum AS
+        OPERATOR        1       documentdb_extended_rum_jsonb_ops_internal.#@@(jsonb, jsonpath),
+        FUNCTION        1       jsonb_cmp(jsonb, jsonb),
+        FUNCTION        2       documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_extract_value(jsonb, internal),
+        FUNCTION        3       documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_extract_query(jsonb, internal, int2, internal, internal, internal, internal),
+        FUNCTION        4       documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_consistent(internal, int2, anyelement, int4, internal, internal),
+        FUNCTION        5       documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_compare_partial(jsonb, jsonb, int2, internal),
+        FUNCTION        11       (jsonb) documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_options(internal),
+    STORAGE         jsonb;
+
+
+-- ALTER OPERATOR FAMILY documentdb_extended_rum_jsonb_ops_internal.jsonb_path_extended_rum_ops USING documentdb_extended_rum ADD OPERATOR 7 documentdb_extended_rum_jsonb_ops_internal.|<>(jsonb, jsonpath) FOR ORDER BY jsonb_ops;
+-- ALTER OPERATOR FAMILY documentdb_extended_rum_jsonb_ops_internal.jsonb_path_extended_rum_ops USING documentdb_extended_rum ADD FUNCTION 8 (jsonb)documentdb_extended_rum_jsonb_ops_internal.jsonb_ordering_transform(jsonb, jsonpath, int2, internal);

--- a/internal/pg_documentdb_extended_rum/sql/schema/jsonb/jsonbpath_operators--0.108-0.sql
+++ b/internal/pg_documentdb_extended_rum/sql/schema/jsonb/jsonbpath_operators--0.108-0.sql
@@ -1,0 +1,13 @@
+
+CREATE OPERATOR documentdb_extended_rum_jsonb_ops.@@@ (
+    LEFTARG = jsonb,
+    RIGHTARG = jsonpath,
+    PROCEDURE = documentdb_extended_rum_jsonb_ops.jsonb_path_match_opr
+);
+
+-- Same operator as @@@ but pushed to the index
+CREATE OPERATOR documentdb_extended_rum_jsonb_ops_internal.#@@ (
+    LEFTARG = jsonb,
+    RIGHTARG = jsonpath,
+    PROCEDURE = documentdb_extended_rum_jsonb_ops.jsonb_path_match_opr
+);

--- a/internal/pg_documentdb_extended_rum/sql/udfs/jsonb/jsonbpath_functions--0.108-0.sql
+++ b/internal/pg_documentdb_extended_rum/sql/udfs/jsonb/jsonbpath_functions--0.108-0.sql
@@ -1,0 +1,13 @@
+
+CREATE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_path_support(internal)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $$jsonb_path_support$$;
+
+CREATE OR REPLACE FUNCTION documentdb_extended_rum_jsonb_ops.jsonb_path_match_opr(jsonb, jsonpath)
+ RETURNS boolean
+ LANGUAGE C
+ SUPPORT documentdb_extended_rum_jsonb_ops_internal.jsonb_path_support
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$jsonb_path_match_docdb_rum$function$;

--- a/internal/pg_documentdb_extended_rum/sql/udfs/jsonb/jsonbpath_operator_class_functions--0.108-0.sql
+++ b/internal/pg_documentdb_extended_rum/sql/udfs/jsonb/jsonbpath_operator_class_functions--0.108-0.sql
@@ -1,0 +1,29 @@
+
+CREATE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_extract_value(jsonb, internal)
+ RETURNS internal
+ LANGUAGE C STRICT IMMUTABLE
+AS 'MODULE_PATHNAME', $function$jsonb_rum_ops_extract_value$function$;
+
+CREATE OR REPLACE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_extract_query(jsonb, internal, int2, internal, internal, internal, internal)
+ RETURNS internal
+ LANGUAGE c
+ PARALLEL SAFE STABLE
+AS 'MODULE_PATHNAME', $function$jsonb_rum_ops_extract_query$function$;
+
+CREATE OR REPLACE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_consistent(internal, int2, anyelement, int4, internal, internal)
+ RETURNS boolean
+ LANGUAGE c
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$jsonb_rum_ops_consistent$function$;
+
+CREATE OR REPLACE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_compare_partial(jsonb, jsonb, int2, internal)
+ RETURNS int4
+ LANGUAGE c
+ IMMUTABLE PARALLEL SAFE STRICT
+ AS 'MODULE_PATHNAME', $function$jsonb_rum_ops_compare_partial$function$;
+
+CREATE OR REPLACE FUNCTION documentdb_extended_rum_jsonb_ops_internal.jsonb_rum_ops_options(internal)
+ RETURNS void
+ LANGUAGE c
+ IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $function$jsonb_rum_ops_options$function$;

--- a/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.c
+++ b/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.c
@@ -1,0 +1,530 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/jsonb/jsonb_path_opclass.c
+ *
+ * Planner support function for jsonbpath for documentdb_rum
+ *-------------------------------------------------------------------------
+ */
+
+
+#include <postgres.h>
+#include <miscadmin.h>
+#include "utils/builtins.h"
+#include <fmgr.h>
+#include <utils/jsonb.h>
+#include <utils/varlena.h>
+#include <utils/numeric.h>
+#include <catalog/pg_collation.h>
+#include <utils/jsonpath.h>
+#include <access/reloptions.h>
+#include "pg_documentdb_rum.h"
+#include "jsonb_path_opclass.h"
+
+#define Get_Index_Path_Option(options, field, result, resultFieldLength) \
+	const char *pathDefinition = GET_STRING_RELOPTION(options, field); \
+	if (pathDefinition == NULL) { resultFieldLength = 0; result = NULL; } \
+	else { resultFieldLength = *(uint32_t *) pathDefinition; result = pathDefinition + \
+																	  sizeof(uint32_t); }
+
+typedef struct JsonbExtendedRumOptions
+{
+	int32 vl_len_;            /* varlena header (do not touch directly!) */
+	bool wildcard;
+	int pathSpec;
+} JsonbExtendedRumOptions;
+
+typedef struct JsonbExtendedQueryData
+{
+	JsonPathItemType operator;
+	JsonbValue rightArgValue;
+} JsonbExtendedQueryData;
+
+PG_FUNCTION_INFO_V1(jsonb_rum_ops_extract_value);
+PG_FUNCTION_INFO_V1(jsonb_rum_ops_extract_query);
+PG_FUNCTION_INFO_V1(jsonb_rum_ops_consistent);
+PG_FUNCTION_INFO_V1(jsonb_rum_ops_compare_partial);
+PG_FUNCTION_INFO_V1(jsonb_rum_ops_options);
+
+
+static Datum * GenerateJsonbTermsCore(Jsonb *inputDoc, JsonbExtendedRumOptions *options,
+									  int32_t *nentries);
+
+
+PGDLLEXPORT Datum
+jsonb_rum_ops_extract_value(PG_FUNCTION_ARGS)
+{
+	Jsonb *inputDoc = PG_GETARG_JSONB_P(0);
+	int32_t *nentries = (int32_t *) PG_GETARG_POINTER(1);
+	if (!PG_HAS_OPCLASS_OPTIONS())
+	{
+		ereport(ERROR, (errmsg("Index does not have options")));
+	}
+
+	JsonbExtendedRumOptions *options =
+		(JsonbExtendedRumOptions *) PG_GET_OPCLASS_OPTIONS();
+
+	Datum *indexEntries = GenerateJsonbTermsCore(inputDoc, options, nentries);
+	PG_RETURN_POINTER(indexEntries);
+}
+
+
+static void
+JsonPathItemToBound(JsonPathItem *item, JsonbValue *bound)
+{
+	switch (item->type)
+	{
+		case jpiString:
+		{
+			bound->type = jbvString;
+			bound->val.string.val = jspGetString(item, &bound->val.string.len);
+			return;
+		}
+
+		case jpiNumeric:
+		{
+			bound->type = jbvNumeric;
+			bound->val.numeric = jspGetNumeric(item);
+			return;
+		}
+
+		case jpiBool:
+		{
+			bound->type = jbvBool;
+			bound->val.boolean = jspGetBool(item);
+			return;
+		}
+
+		default:
+		{
+			ereport(ERROR, (errmsg("Unsupported jsonpath type for index bound %d",
+								   item->type)));
+		}
+	}
+}
+
+
+PGDLLEXPORT Datum
+jsonb_rum_ops_extract_query(PG_FUNCTION_ARGS)
+{
+	/* StrategyNumber strategy = PG_GETARG_UINT16(2); */
+	JsonPath *query = PG_GETARG_JSONPATH_P(0);
+	int32 *nentries = (int32 *) PG_GETARG_POINTER(1);
+	bool **partialmatch = (bool **) PG_GETARG_POINTER(3);
+	Pointer **extra_data = (Pointer **) PG_GETARG_POINTER(4);
+	/* int32_t *searchMode = (int32_t *) PG_GETARG_POINTER(6); */
+
+	if (!PG_HAS_OPCLASS_OPTIONS())
+	{
+		ereport(ERROR, (errmsg("Index does not have options")));
+	}
+
+	JsonbExtendedRumOptions *options =
+		(JsonbExtendedRumOptions *) PG_GET_OPCLASS_OPTIONS();
+
+	JsonPathItem jpi;
+	jspInit(&jpi, query);
+
+	*nentries = 1;
+	*partialmatch = palloc0(sizeof(bool) * 1);
+	*extra_data = palloc0(sizeof(Pointer) * 1);
+
+	Datum *result = palloc0(sizeof(Datum) * 1);
+
+	JsonPathItem rightArg;
+	jspGetRightArg(&jpi, &rightArg);
+
+	JsonbExtendedQueryData *queryData = palloc0(sizeof(JsonbExtendedQueryData));
+	(*extra_data)[0] = (Pointer) queryData;
+
+	queryData->operator = jpi.type;
+
+	JsonbValue bound;
+	switch (jpi.type)
+	{
+		case jpiEqual:
+		{
+			JsonPathItemToBound(&rightArg, &bound);
+			(*partialmatch)[0] = false;
+			queryData->rightArgValue = bound;
+			break;
+		}
+
+		case jpiGreater:
+		case jpiGreaterOrEqual:
+		{
+			JsonPathItemToBound(&rightArg, &bound);
+			(*partialmatch)[0] = true;
+			queryData->rightArgValue = bound;
+			break;
+		}
+
+		case jpiLess:
+		case jpiLessOrEqual:
+		{
+			/* Start from null */
+			bound.type = jbvNull;
+			(*partialmatch)[0] = true;
+			JsonPathItemToBound(&rightArg, &queryData->rightArgValue);
+			break;
+		}
+
+		default:
+		{
+			ereport(ERROR, (errmsg("Unsupported query operator %d", jpi.type)));
+		}
+	}
+
+	if (options->wildcard)
+	{
+		/* We need a path prefix */
+		if (!IsAJsonbScalar(&bound))
+		{
+			ereport(ERROR, (errmsg("Wildcard not yet supported")));
+		}
+
+		JsonbValue container = bound;
+		container.type = jbvObject;
+		container.val.object.nPairs = 1;
+		container.val.object.pairs = palloc(sizeof(JsonbPair) * 1);
+		container.val.object.pairs[0].key.type = jbvString;
+		container.val.object.pairs[0].key.val.string.len = 1;
+		container.val.object.pairs[0].key.val.string.val = "$";
+		container.val.object.pairs[0].value = bound;
+
+		result[0] = PointerGetDatum(JsonbValueToJsonb(&container));
+		*nentries = 1;
+	}
+	else
+	{
+		result[0] = PointerGetDatum(JsonbValueToJsonb(&bound));
+		*nentries = 1;
+	}
+
+	PG_RETURN_POINTER(result);
+}
+
+
+PGDLLEXPORT Datum
+jsonb_rum_ops_consistent(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(true);
+}
+
+
+static int32_t
+compareJsonbValues(JsonbValue *left, JsonbValue *right)
+{
+	if (left->type != right->type)
+	{
+		return left->type - right->type;
+	}
+
+	switch (left->type)
+	{
+		case jbvNull:
+		{
+			return 0;
+		}
+
+		case jbvString:
+		{
+			return varstr_cmp(left->val.string.val,
+							  left->val.string.len,
+							  right->val.string.val,
+							  right->val.string.len,
+							  DEFAULT_COLLATION_OID);
+		}
+
+		case jbvNumeric:
+		{
+			return DatumGetInt32(DirectFunctionCall2(numeric_cmp,
+													 PointerGetDatum(left->val.numeric),
+													 PointerGetDatum(
+														 right->val.numeric)));
+		}
+
+		case jbvBool:
+		{
+			if (left->val.boolean == right->val.boolean)
+			{
+				return 0;
+			}
+			else if (left->val.boolean > right->val.boolean)
+			{
+				return 1;
+			}
+			else
+			{
+				return -1;
+			}
+		}
+
+		default:
+        {
+			elog(ERROR, "unsupported type for comparison");
+        }
+			
+	}
+	return 0;
+}
+
+
+PGDLLEXPORT Datum
+jsonb_rum_ops_compare_partial(PG_FUNCTION_ARGS)
+{
+	Jsonb *compareValue = PG_GETARG_JSONB_P(1);
+	/* StrategyNumber strategy = PG_GETARG_UINT16(2); */
+	Pointer extraData = PG_GETARG_POINTER(3);
+
+	JsonbExtendedQueryData *runData = (JsonbExtendedQueryData *) extraData;
+	JsonbValue *indexValue = getIthJsonbValueFromContainer(&compareValue->root, 0);
+	switch (runData->operator)
+	{
+		case jpiGreater:
+		{
+			int32_t cmp = compareJsonbValues(indexValue, &runData->rightArgValue);
+			return cmp > 0 ? 0 : -1;
+		}
+
+		case jpiGreaterOrEqual:
+		{
+			int32_t cmp = compareJsonbValues(indexValue, &runData->rightArgValue);
+			return cmp >= 0 ? 0 : -1;
+		}
+
+		case jpiLess:
+		{
+			int32_t cmp = compareJsonbValues(indexValue, &runData->rightArgValue);
+			return cmp < 0 ? 0 : 1;
+		}
+
+		case jpiLessOrEqual:
+		{
+			int32_t cmp = compareJsonbValues(indexValue, &runData->rightArgValue);
+			return cmp <= 0 ? 0 : 1;
+		}
+
+		default:
+		{
+			ereport(ERROR, (errmsg("Unsupported query operator %d", runData->operator)));
+		}
+	}
+}
+
+
+static void
+ValidatePathSpec(const char *prefix)
+{
+	int i;
+	if (prefix == NULL)
+	{
+		/* validate can be called with the default value NULL. */
+		return;
+	}
+
+	int32_t stringLength = strlen(prefix);
+	if (stringLength < 1)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg(
+							"at least one filter path must be specified")));
+	}
+
+	if (prefix[0] != '$')
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg(
+							"filter path must start with '$'")));
+	}
+
+	if ((stringLength > 1 && prefix[1] != '.') || stringLength == 2)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg(
+							"filter path must be exactly '$' or start with '$.'")));
+	}
+
+	for (i = 1; i < stringLength; i++)
+	{
+		if (!isalnum(prefix[i]) && prefix[i] != '.')
+		{
+			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg(
+								"only simple jsonbpath filters supported currently")));
+		}
+	}
+}
+
+
+static Size
+FillPathSpec(const char *prefix, void *buffer)
+{
+	if (prefix == NULL)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg(
+							"at least one filter path must be specified")));
+	}
+
+	uint32_t totalSize = strlen(prefix) + 5;
+
+	if (buffer != NULL)
+	{
+		char *bufferPtr = (char *) buffer;
+		*((uint32_t *) bufferPtr) = strlen(prefix);
+		bufferPtr += sizeof(uint32_t);
+
+		strcpy(bufferPtr, prefix);
+	}
+
+	return totalSize;
+}
+
+
+PGDLLEXPORT Datum
+jsonb_rum_ops_options(PG_FUNCTION_ARGS)
+{
+	local_relopts *relopts = (local_relopts *) PG_GETARG_POINTER(0);
+
+	init_local_reloptions(relopts, sizeof(JsonbExtendedRumOptions));
+
+	add_local_string_reloption(relopts, "pathspec",
+							   "path to index",
+							   NULL, &ValidatePathSpec, &FillPathSpec,
+							   offsetof(JsonbExtendedRumOptions, pathSpec));
+	add_local_bool_reloption(relopts, "wildcard",
+							 "whether or not the path is a wildcard (recursive) index",
+							 false, offsetof(JsonbExtendedRumOptions, wildcard));
+
+	PG_RETURN_VOID();
+}
+
+
+const char *
+GetIndexPathFromOptions(bytea *options, uint32_t *searchPathLength)
+{
+	JsonbExtendedRumOptions *rumOptions = (JsonbExtendedRumOptions *) options;
+	const char *path;
+	Get_Index_Path_Option(rumOptions, pathSpec, path, *searchPathLength);
+	return path;
+}
+
+
+static bool
+FindPathInJsonbValue(JsonbValue *inputValue, const char *path, uint32_t pathLength)
+{
+	check_stack_depth();
+	CHECK_FOR_INTERRUPTS();
+	if (inputValue->type != jbvObject && inputValue->type != jbvBinary)
+	{
+		return false;
+	}
+
+	char *firstDot = strchr(path, '.');
+
+	JsonbValue searchKey = { 0 };
+	searchKey.type = jbvString;
+	searchKey.val.string.len = pathLength;
+	searchKey.val.string.val = (char *) path;
+	if (firstDot != NULL)
+	{
+		searchKey.val.string.len = firstDot - path;
+	}
+
+	bool found = false;
+	if (inputValue->type == jbvBinary)
+	{
+		JsonbValue *foundValue = findJsonbValueFromContainer(inputValue->val.binary.data,
+															 JB_FOBJECT, &searchKey);
+		if (foundValue != NULL)
+		{
+			found = true;
+			*inputValue = *foundValue;
+		}
+	}
+	else
+	{
+		for (int i = 0; i < inputValue->val.object.nPairs; i++)
+		{
+			if (inputValue->val.object.pairs[i].key.val.string.len ==
+				searchKey.val.string.len &&
+				strncmp(inputValue->val.object.pairs[i].key.val.string.val,
+						searchKey.val.string.val, searchKey.val.string.len) == 0)
+			{
+				found = true;
+				*inputValue = inputValue->val.object.pairs[i].value;
+				break;
+			}
+		}
+	}
+
+	if (!found)
+	{
+		return false;
+	}
+
+	if (firstDot == NULL)
+	{
+		return true;
+	}
+
+	char *suffix = firstDot + 1;
+	uint32_t remainingLength = (&path[pathLength - 1] - suffix) + 1;
+	return FindPathInJsonbValue(inputValue, suffix, remainingLength);
+}
+
+
+static Datum *
+GenerateJsonbTermsCore(Jsonb *inputDoc, JsonbExtendedRumOptions *options,
+					   int32_t *nentries)
+{
+	const char *path;
+	uint32_t pathLength;
+	Get_Index_Path_Option(options, pathSpec, path, pathLength);
+
+	/* Find the prefix for path term generation first */
+	JsonbValue jbv;
+	JsonbToJsonbValue(inputDoc, &jbv);
+
+	if (pathLength > 1)
+	{
+		/* if it's not just '$', then find the subtree */
+		if (!FindPathInJsonbValue(&jbv, path + 2, pathLength - 2))
+		{
+			*nentries = 0;
+			return NULL;
+		}
+	}
+
+	/* We now have a value from which to generate terms */
+	Datum *entries = palloc(sizeof(Datum) * 1);
+	if (options->wildcard)
+	{
+		/* We need a path prefix */
+		if (!IsAJsonbScalar(&jbv))
+		{
+			ereport(ERROR, (errmsg("Wildcard not yet supported")));
+		}
+
+		JsonbValue container = jbv;
+		container.type = jbvObject;
+		container.val.object.nPairs = 1;
+		container.val.object.pairs = palloc(sizeof(JsonbPair) * 1);
+		container.val.object.pairs[0].key.type = jbvString;
+		container.val.object.pairs[0].key.val.string.len = 1;
+		container.val.object.pairs[0].key.val.string.val = "$";
+		container.val.object.pairs[0].value = jbv;
+
+		entries[0] = PointerGetDatum(JsonbValueToJsonb(&container));
+		*nentries = 1;
+	}
+	else
+	{
+		entries[0] = PointerGetDatum(JsonbValueToJsonb(&jbv));
+		*nentries = 1;
+	}
+
+	if (message_level_is_interesting(DEBUG1))
+	{
+		char *jsonbString = JsonbToCString(NULL, &(DatumGetJsonbP(entries[0])->root), 0);
+		elog(DEBUG1, "First term %s", jsonbString);
+	}
+
+	return entries;
+}

--- a/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.c
+++ b/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.c
@@ -112,6 +112,7 @@ jsonb_rum_ops_extract_query(PG_FUNCTION_ARGS)
 	int32 *nentries = (int32 *) PG_GETARG_POINTER(1);
 	bool **partialmatch = (bool **) PG_GETARG_POINTER(3);
 	Pointer **extra_data = (Pointer **) PG_GETARG_POINTER(4);
+
 	/* int32_t *searchMode = (int32_t *) PG_GETARG_POINTER(6); */
 
 	if (!PG_HAS_OPCLASS_OPTIONS())
@@ -261,10 +262,9 @@ compareJsonbValues(JsonbValue *left, JsonbValue *right)
 		}
 
 		default:
-        {
+		{
 			elog(ERROR, "unsupported type for comparison");
-        }
-			
+		}
 	}
 	return 0;
 }
@@ -274,6 +274,7 @@ PGDLLEXPORT Datum
 jsonb_rum_ops_compare_partial(PG_FUNCTION_ARGS)
 {
 	Jsonb *compareValue = PG_GETARG_JSONB_P(1);
+
 	/* StrategyNumber strategy = PG_GETARG_UINT16(2); */
 	Pointer extraData = PG_GETARG_POINTER(3);
 

--- a/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.h
+++ b/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_opclass.h
@@ -1,0 +1,16 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/jsonb/jsonb_path_opclass.h
+ *
+ * Common declarations of the jsonb opclass management
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef JSONB_PATH_OPCLASS_H
+#define JSONB_PATH_OPCLASS_H
+
+const char * GetIndexPathFromOptions(bytea *options, uint32_t *searchPathLength);
+
+#endif

--- a/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_support.c
+++ b/internal/pg_documentdb_extended_rum/src/jsonb/jsonb_path_support.c
@@ -1,0 +1,286 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/jsonb/jsonb_path_support.c
+ *
+ * Planner support function for jsonbpath for documentdb_rum
+ *-------------------------------------------------------------------------
+ */
+
+
+#include <postgres.h>
+#include <miscadmin.h>
+#include <fmgr.h>
+#include <nodes/pathnodes.h>
+#include <catalog/pg_am.h>
+#include <utils/syscache.h>
+#include <parser/parse_func.h>
+#include <nodes/supportnodes.h>
+#include <nodes/makefuncs.h>
+#include <utils/jsonpath.h>
+#include <commands/defrem.h>
+#include "pg_documentdb_rum.h"
+#include "jsonb_path_opclass.h"
+
+
+PG_FUNCTION_INFO_V1(jsonb_path_support);
+PG_FUNCTION_INFO_V1(jsonb_path_match_docdb_rum);
+
+extern Datum jsonb_path_match_opr(PG_FUNCTION_ARGS);
+
+static Oid JsonbPathMatchFuncOid(void);
+static Expr * HandleSupportJsonPathMatch(SupportRequestIndexCondition *indexCond);
+
+typedef struct PlannerOidCache
+{
+	Oid jsonbPathMatchFuncOid;
+	Oid jsonPathMatchIndexOperatorOid;
+	Oid documentDBExtendedRumAmOid;
+	Oid documentDBJsonPathOpFamily;
+} PlannerOidCache;
+
+static PlannerOidCache OidCache = { 0 };
+
+
+PGDLLEXPORT Datum
+jsonb_path_support(PG_FUNCTION_ARGS)
+{
+	Node *supportRequest = (Node *) PG_GETARG_POINTER(0);
+	Pointer responsePointer = NULL;
+	if (IsA(supportRequest, SupportRequestIndexCondition))
+	{
+		SupportRequestIndexCondition *indexSupport =
+			(SupportRequestIndexCondition *) supportRequest;
+		if (indexSupport->funcid == JsonbPathMatchFuncOid())
+		{
+			responsePointer = (Pointer) HandleSupportJsonPathMatch(indexSupport);
+		}
+	}
+
+	PG_RETURN_POINTER(responsePointer);
+}
+
+
+PGDLLEXPORT Datum
+jsonb_path_match_docdb_rum(PG_FUNCTION_ARGS)
+{
+	/* Pass through to the postgres C function */
+	return jsonb_path_match_opr(fcinfo);
+}
+
+
+static Oid
+JsonbPathMatchFuncOid(void)
+{
+	if (OidCache.jsonbPathMatchFuncOid == InvalidOid)
+	{
+		List *functionNameList = list_make2(makeString(
+												"documentdb_extended_rum_jsonb_ops"),
+											makeString("jsonb_path_match_opr"));
+		Oid paramOids[2] = { JSONBOID, JSONPATHOID };
+		bool missingOK = false;
+		OidCache.jsonbPathMatchFuncOid =
+			LookupFuncName(functionNameList, 2, paramOids, missingOK);
+	}
+
+	return OidCache.jsonbPathMatchFuncOid;
+}
+
+
+static Oid
+JsonbPathMatchIndexOperatorOid(void)
+{
+	if (OidCache.jsonPathMatchIndexOperatorOid == InvalidOid)
+	{
+		List *operatorNameList = list_make2(makeString(
+												"documentdb_extended_rum_jsonb_ops_internal"),
+											makeString("#@@"));
+
+		OidCache.jsonPathMatchIndexOperatorOid =
+			OpernameGetOprid(operatorNameList, JSONBOID, JSONPATHOID);
+	}
+
+	return OidCache.jsonPathMatchIndexOperatorOid;
+}
+
+
+static Oid
+DocumentDBExtendedRumAmOid(void)
+{
+	if (OidCache.documentDBExtendedRumAmOid == InvalidOid)
+	{
+		HeapTuple tuple = SearchSysCache1(AMNAME, CStringGetDatum(
+											  "documentdb_extended_rum"));
+		if (!HeapTupleIsValid(tuple))
+		{
+			ereport(ERROR,
+					(errmsg("Access method \"documentdb_extended_rum\" not supported.")));
+		}
+		Form_pg_am accessMethodForm = (Form_pg_am) GETSTRUCT(tuple);
+		OidCache.documentDBExtendedRumAmOid = accessMethodForm->oid;
+		ReleaseSysCache(tuple);
+	}
+
+	return OidCache.documentDBExtendedRumAmOid;
+}
+
+
+static Oid
+DocumentDBJsonPathOpFamily(void)
+{
+	if (OidCache.documentDBJsonPathOpFamily == InvalidOid)
+	{
+		bool missingOk = false;
+		OidCache.documentDBJsonPathOpFamily = get_opfamily_oid(
+			DocumentDBExtendedRumAmOid(), list_make2(makeString(
+														 "documentdb_extended_rum_jsonb_ops"),
+													 makeString(
+														 "jsonb_path_extended_rum_ops")),
+			missingOk);
+	}
+
+	return OidCache.documentDBJsonPathOpFamily;
+}
+
+
+static bool
+IndexSupportsPath(JsonPathItem *jpi, const char *indexPath, uint32_t indexPathLength)
+{
+	if (jpi->type == jpiRoot)
+	{
+		if (indexPathLength < 1 || indexPath[0] != '$')
+		{
+			return false;
+		}
+
+		JsonPathItem next;
+		if (!jspGetNext(jpi, &next))
+		{
+			return indexPathLength == 1;
+		}
+
+		return IndexSupportsPath(&next, indexPath + 2, indexPathLength - 2);
+	}
+	else if (jpi->type == jpiKey)
+	{
+		int32_t keyLength = 0;
+		const char *key = jspGetString(jpi, &keyLength);
+
+		if (keyLength > indexPathLength)
+		{
+			return false;
+		}
+
+		if (strncmp(key, indexPath, keyLength) != 0)
+		{
+			return false;
+		}
+
+		JsonPathItem next;
+		if (!jspGetNext(jpi, &next))
+		{
+			return indexPathLength == keyLength;
+		}
+
+		if (indexPathLength < keyLength + 2)
+		{
+			return false;
+		}
+
+		return IndexSupportsPath(&next, indexPath + 2, indexPathLength - 2);
+	}
+
+	return false;
+}
+
+
+static Expr *
+HandleSupportJsonPathMatch(SupportRequestIndexCondition *indexCond)
+{
+	if (indexCond->index->relam != DocumentDBExtendedRumAmOid())
+	{
+		return NULL;
+	}
+
+	if (indexCond->index->opfamily[indexCond->indexcol] != DocumentDBJsonPathOpFamily() ||
+		indexCond->index->opclassoptions[indexCond->indexcol] == NULL)
+	{
+		return NULL;
+	}
+
+	bytea *opclassOptions =
+		(bytea *) indexCond->index->opclassoptions[indexCond->indexcol];
+
+	uint32_t searchPathLength = 0;
+	const char *searchPath = GetIndexPathFromOptions(opclassOptions, &searchPathLength);
+
+	List *exprArgs = NIL;
+	if (IsA(indexCond->node, FuncExpr))
+	{
+		FuncExpr *function = (FuncExpr *) indexCond->node;
+		exprArgs = function->args;
+	}
+	else if (IsA(indexCond->node, OpExpr))
+	{
+		OpExpr *opExpr = (OpExpr *) indexCond->node;
+		exprArgs = opExpr->args;
+	}
+
+	if (list_length(exprArgs) != 2)
+	{
+		return NULL;
+	}
+
+	Node *secondArg = lsecond(exprArgs);
+	if (!IsA(secondArg, Const))
+	{
+		return NULL;
+	}
+
+	Const *secondConst = (Const *) secondArg;
+	if (secondConst->constisnull)
+	{
+		return NULL;
+	}
+
+	JsonPath *path = DatumGetJsonPathP(secondConst->constvalue);
+	JsonPathItem jpi;
+	jspInit(&jpi, path);
+
+	if (jpi.type == jpiEqual ||
+		(jpi.type >= jpiLess && jpi.type <= jpiGreaterOrEqual))
+	{
+		if (jspHasNext(&jpi))
+		{
+			return NULL;
+		}
+
+		JsonPathItem leftArg, rightArg;
+		jspGetLeftArg(&jpi, &leftArg);
+		jspGetRightArg(&jpi, &rightArg);
+
+		/* Valid support - others are not */
+		if (rightArg.type > jpiBool)
+		{
+			return NULL;
+		}
+
+		if (!IndexSupportsPath(&leftArg, searchPath, searchPathLength))
+		{
+			return NULL;
+		}
+
+		/* Valid index expr */
+		OpExpr *opExpr = (OpExpr *) make_opclause(JsonbPathMatchIndexOperatorOid(),
+												  BOOLOID,
+												  false,
+												  linitial(exprArgs),
+												  lsecond(exprArgs),
+												  InvalidOid,
+												  InvalidOid);
+		opExpr->opfuncid = JsonbPathMatchFuncOid();
+		return (Expr *) list_make1(opExpr);
+	}
+
+	return NULL;
+}

--- a/internal/pg_documentdb_extended_rum/src/test/Makefile
+++ b/internal/pg_documentdb_extended_rum/src/test/Makefile
@@ -1,0 +1,6 @@
+subdir = src/test
+
+check-regress:
+	$(MAKE) -C regress all
+
+all: check-regress

--- a/internal/pg_documentdb_extended_rum/src/test/regress/.gitignore
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+log/
+results/
+regression.diffs
+!expected/*.out

--- a/internal/pg_documentdb_extended_rum/src/test/regress/Makefile
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/Makefile
@@ -1,0 +1,34 @@
+
+BASEPATH:=../../../
+
+REGRESS := 1
+
+PG_CONFIG ?= pg_config
+
+# export pg_config for child make commands (check etc)
+export PG_CONFIG
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+
+EXTENSIONLOAD := --load-extension=pg_cron --load-extension=tsm_system_rows --load-extension=vector --load-extension=postgis --load-extension=rum --load-extension=documentdb_core --load-extension=documentdb --load-extension=documentdb_extended_rum
+
+MAKEFILE_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+export PATH := $(MAKEFILE_DIR)bin:$(PATH)
+export PG_REGRESS_DIFF_OPTS = -dU10
+
+export PGISOLATIONTIMEOUT = 60
+
+.PHONY: check-basic check-minimal
+
+define common_test
+	$(top_builddir)/src/test/regress/pg_regress --encoding=UTF8 --dlpath=$(BASEPATH) $(EXTENSIONLOAD) --temp-instance ./tmp --temp-config ./postgresql.conf --host localhost --port 58090 $(1) $(2) || (cat regression.diffs && false)
+endef
+
+check-basic:
+	$(call common_test,--schedule=./basic_schedule)
+
+check-minimal:
+	$(call common_test,--schedule=./minimal_schedule, $(EXTRA_TESTS))
+
+all: check-basic

--- a/internal/pg_documentdb_extended_rum/src/test/regress/basic_schedule
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/basic_schedule
@@ -1,0 +1,1 @@
+test: basic_jsonb_query_pushdown

--- a/internal/pg_documentdb_extended_rum/src/test/regress/expected/basic_jsonb_query_pushdown.out
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/expected/basic_jsonb_query_pushdown.out
@@ -1,0 +1,113 @@
+set search_path to documentdb_extended_rum_jsonb_ops,public;
+CREATE TABLE public.jsonb_basic_query (val jsonb);
+INSERT INTO public.jsonb_basic_query VALUES ('{ "a": { "b": 1, "c": 3 }}'), ('{ "a": { "b": 2, "c": 4 }}');
+-- can query as runtime can use the new jsonpath operator
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+           val           
+-------------------------
+ {"a": {"b": 2, "c": 4}}
+(1 row)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 1';
+           val           
+-------------------------
+ {"a": {"b": 1, "c": 3}}
+(1 row)
+
+-- it's a seqscan that executes it
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+                    QUERY PLAN                    
+--------------------------------------------------
+ Seq Scan on jsonb_basic_query
+   Filter: (val @@@ '($."a"."b" == 2)'::jsonpath)
+(2 rows)
+
+-- now create an extended_rum index on the jsonb
+set client_min_messages to DEBUG1;
+CREATE INDEX my_idx_ab ON public.jsonb_basic_query USING documentdb_extended_rum(val jsonb_path_extended_rum_ops(pathspec='$.a.b',wildcard=true));
+DEBUG:  building index "my_idx_ab" on table "jsonb_basic_query" serially
+DEBUG:  First term {"$": 1}
+DEBUG:  First term {"$": 2}
+CREATE INDEX my_idx_ac ON public.jsonb_basic_query USING documentdb_extended_rum(val jsonb_path_extended_rum_ops(pathspec='$.a.c'));
+DEBUG:  building index "my_idx_ac" on table "jsonb_basic_query" serially
+DEBUG:  First term 3
+DEBUG:  First term 4
+reset client_min_messages;
+-- now each query gets pushed to the appropriate index.
+set enable_seqscan to off;
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Index Scan using my_idx_ab on jsonb_basic_query
+   Index Cond: (val OPERATOR(documentdb_extended_rum_jsonb_ops_internal.#@@) '($."a"."b" == 2)'::jsonpath)
+   Filter: (val @@@ '($."a"."b" == 2)'::jsonpath)
+(3 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b.c == 2';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Seq Scan on jsonb_basic_query
+   Filter: (val @@@ '($."a"."b"."c" == 2)'::jsonpath)
+(2 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 2';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Index Scan using my_idx_ac on jsonb_basic_query
+   Index Cond: (val OPERATOR(documentdb_extended_rum_jsonb_ops_internal.#@@) '($."a"."c" == 2)'::jsonpath)
+   Filter: (val @@@ '($."a"."c" == 2)'::jsonpath)
+(3 rows)
+
+-- but this one can't be pushed (since a.c is not a wildcard)
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c.d == 2';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Seq Scan on jsonb_basic_query
+   Filter: (val @@@ '($."a"."c"."d" == 2)'::jsonpath)
+(2 rows)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+           val           
+-------------------------
+ {"a": {"b": 2, "c": 4}}
+(1 row)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b.c == 2';
+ val 
+-----
+(0 rows)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 2';
+ val 
+-----
+(0 rows)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 4';
+           val           
+-------------------------
+ {"a": {"b": 2, "c": 4}}
+(1 row)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c > 3';
+           val           
+-------------------------
+ {"a": {"b": 2, "c": 4}}
+(1 row)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c > 4';
+ val 
+-----
+(0 rows)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c < 2';
+ val 
+-----
+(0 rows)
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c < 5';
+           val           
+-------------------------
+ {"a": {"b": 1, "c": 3}}
+ {"a": {"b": 2, "c": 4}}
+(2 rows)
+

--- a/internal/pg_documentdb_extended_rum/src/test/regress/postgresql.conf
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/postgresql.conf
@@ -1,0 +1,9 @@
+shared_preload_libraries = 'pg_cron,pg_documentdb_core,pg_documentdb,pg_documentdb_extended_rum'
+
+# Set default encoding to UTF8 for testing
+client_encoding = 'UTF8'
+
+max_connections = 300
+cron.database_name = 'regression'
+
+# documentdb_core.bsonUseEJson = 'on'

--- a/internal/pg_documentdb_extended_rum/src/test/regress/sql/basic_jsonb_query_pushdown.sql
+++ b/internal/pg_documentdb_extended_rum/src/test/regress/sql/basic_jsonb_query_pushdown.sql
@@ -1,0 +1,37 @@
+set search_path to documentdb_extended_rum_jsonb_ops,public;
+
+CREATE TABLE public.jsonb_basic_query (val jsonb);
+
+INSERT INTO public.jsonb_basic_query VALUES ('{ "a": { "b": 1, "c": 3 }}'), ('{ "a": { "b": 2, "c": 4 }}');
+
+-- can query as runtime can use the new jsonpath operator
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 1';
+
+-- it's a seqscan that executes it
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+
+-- now create an extended_rum index on the jsonb
+set client_min_messages to DEBUG1;
+CREATE INDEX my_idx_ab ON public.jsonb_basic_query USING documentdb_extended_rum(val jsonb_path_extended_rum_ops(pathspec='$.a.b',wildcard=true));
+CREATE INDEX my_idx_ac ON public.jsonb_basic_query USING documentdb_extended_rum(val jsonb_path_extended_rum_ops(pathspec='$.a.c'));
+reset client_min_messages;
+
+-- now each query gets pushed to the appropriate index.
+set enable_seqscan to off;
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b.c == 2';
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 2';
+
+-- but this one can't be pushed (since a.c is not a wildcard)
+EXPLAIN (COSTS OFF) SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c.d == 2';
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b == 2';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.b.c == 2';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 2';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c == 4';
+
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c > 3';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c > 4';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c < 2';
+SELECT * FROM public.jsonb_basic_query WHERE val @@@ '$.a.c < 5';


### PR DESCRIPTION
Add simple support as a reference implementation sketch of jsonbpath with simple comparison operators for documentdb_rum.

Note: this needs to be extended significantly to support more scenarios but presents a sample of what can be done.