### PR TITLE
Add support for initialize with initial data file

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -44,8 +44,15 @@ RUN sudo groupmod -g 103 postgres && sudo usermod -u 105 -g 103 postgres
 
 RUN sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends \
-    jq openssl lsof && \
+    jq openssl lsof wget gnupg netcat-openbsd && \
     sudo apt-get upgrade -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add - && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list && \
+    sudo apt-get update && \
+    sudo apt-get install -y mongodb-mongosh && \
+    sudo apt-get clean && \
     sudo rm -rf /var/lib/apt/lists/*
 
 ENV LANGUAGE=en_US.UTF-8 \
@@ -63,6 +70,8 @@ ENV CERT_PATH="" \
     POSTGRESQL_PORT="9712" \
     OWNER="documentdb" \
     ALLOW_EXTERNAL_CONNECTIONS="false" \
+    INIT_DATA="false" \
+    INIT_DATA_PATH="/init_doc_db.d" \
     PATH=/usr/lib/postgresql/16/bin:$PATH
 
 RUN sudo mkdir /home/documentdb/gateway
@@ -76,7 +85,19 @@ COPY --from=stage /home/documentdb/code/scripts/emulator_entrypoint.sh /home/doc
 COPY --from=stage /home/documentdb/code/scripts/utils.sh /home/documentdb/gateway/scripts/utils.sh
 COPY --from=stage /home/documentdb/code/scripts/setup_psqlrc.sh /home/documentdb/gateway/scripts/setup_psqlrc.sh
 
+# Copy initialization scripts
+COPY --from=stage /home/documentdb/code/scripts/init_documentdb_data.sh /home/documentdb/gateway/scripts/init_documentdb_data.sh
+
+# Copy sample data for built-in initialization
+COPY --from=stage /home/documentdb/code/sample-data /home/documentdb/gateway/sample-data
+
+# Create default initialization directory for user-provided scripts
+RUN sudo mkdir -p /init_doc_db.d
+
 RUN sudo chown -R documentdb:documentdb /home/documentdb/gateway
+
+# Make initialization script executable
+RUN sudo chmod +x /home/documentdb/gateway/scripts/init_documentdb_data.sh
 
 WORKDIR /home/documentdb/gateway/scripts
 ENTRYPOINT ["/bin/bash", "-c", "/home/documentdb/gateway/scripts/emulator_entrypoint.sh \"$@\"", "--"]

--- a/docs/v1/data-initialization.md
+++ b/docs/v1/data-initialization.md
@@ -1,0 +1,56 @@
+# Data Initialization Support
+
+This file documents the data initialization feature in DocumentDB that allows users to initialize their database with custom data or built-in sample data.
+
+## Environment Variables
+
+The following environment variables are supported:
+
+- `INIT_DATA_PATH`: Path to directory containing .js initialization files (default: /init_doc_db.d)
+- `INIT_DATA`: Enable built-in sample data initialization (default: false)
+
+## Command Line Options
+
+- `--init-data-path [PATH]`: Specify directory containing JavaScript files for database initialization
+- `--init-data`: Enable initialization with built-in sample data (flag, defaults to false)
+
+## Usage Examples
+
+### Using built-in sample data
+```bash
+docker run -p 10260:10260 -p 9712:9712 \
+  --init-data \
+  --password mypassword \
+  documentdb/local
+```
+
+### Using custom initialization files
+```bash
+docker run -p 10260:10260 -p 9712:9712 \
+  -v /path/to/your/init/scripts:/init_doc_db.d \
+  --init-data-path /init_doc_db.d \
+  --password mypassword \
+  documentdb/local
+```
+
+### Using environment variables
+```bash
+docker run -p 10260:10260 -p 9712:9712 \
+  -e INIT_DATA_PATH=/custom/init/path \
+  -e INIT_DATA=true \
+  -e PASSWORD=mypassword \
+  -v /path/to/your/init/scripts:/custom/init/path \
+  documentdb/local
+```
+
+## Built-in Sample Data
+
+When using `--init-data` flag or `INIT_DATA=true`, the following sample collections are created in the 'sampledb' database:
+- users (5 sample users)
+- products (5 sample products)  
+- orders (4 sample orders)
+- analytics (sample metrics and activity data)
+
+## Security Note
+
+Built-in sample data is disabled by default. Custom initialization scripts can be provided for production use.

--- a/docs/v1/index.md
+++ b/docs/v1/index.md
@@ -20,6 +20,7 @@ A curated collection of guides to help you understand what DocumentDB is, why it
 - [Aggregation](v1/aggregation.md)
 - [Joins](v1/joins.md)
 - [Packaging](v1/packaging.md)
+- [Data Initialization](v1/data-initialization.md)
 
 ---
 

--- a/sample-data/01-users.js
+++ b/sample-data/01-users.js
@@ -1,0 +1,109 @@
+// Initialize users collection with sample data
+print("Initializing users collection...");
+
+// Switch to the sampledb database
+use('sampledb');
+
+// Create users collection and insert sample users
+db.users.insertMany([
+    {
+        _id: "user1",
+        username: "alice_smith",
+        email: "alice.smith@example.com",
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 28,
+        city: "Seattle",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-01-15T10:30:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: true,
+            theme: "dark"
+        },
+        tags: ["premium", "early_adopter"]
+    },
+    {
+        _id: "user2",
+        username: "bob_jones",
+        email: "bob.jones@example.com",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 35,
+        city: "San Francisco",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-02-20T14:15:00Z"),
+        preferences: {
+            newsletter: false,
+            notifications: true,
+            theme: "light"
+        },
+        tags: ["standard"]
+    },
+    {
+        _id: "user3",
+        username: "carol_wilson",
+        email: "carol.wilson@example.com",
+        firstName: "Carol",
+        lastName: "Wilson",
+        age: 42,
+        city: "New York",
+        country: "USA",
+        isActive: false,
+        createdAt: new Date("2024-03-10T09:45:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: false,
+            theme: "light"
+        },
+        tags: ["premium", "vip"]
+    },
+    {
+        _id: "user4",
+        username: "david_lee",
+        email: "david.lee@example.com",
+        firstName: "David",
+        lastName: "Lee",
+        age: 31,
+        city: "Austin",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-04-05T16:20:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: true,
+            theme: "dark"
+        },
+        tags: ["standard", "developer"]
+    },
+    {
+        _id: "user5",
+        username: "eve_brown",
+        email: "eve.brown@example.com",
+        firstName: "Eve",
+        lastName: "Brown",
+        age: 26,
+        city: "Portland",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-05-12T11:00:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: false,
+            theme: "auto"
+        },
+        tags: ["premium", "beta_tester"]
+    }
+]);
+
+print("Created " + db.users.countDocuments() + " users in the users collection");
+
+// Create indexes for better query performance
+db.users.createIndex({ "email": 1 }, { unique: true });
+db.users.createIndex({ "username": 1 }, { unique: true });
+db.users.createIndex({ "city": 1 });
+db.users.createIndex({ "tags": 1 });
+
+print("Created indexes on users collection");

--- a/sample-data/02-products.js
+++ b/sample-data/02-products.js
@@ -1,0 +1,147 @@
+// Initialize products collection with sample data
+print("Initializing products collection...");
+
+// Switch to the sampledb database
+use('sampledb');
+
+// Create products collection and insert sample products
+db.products.insertMany([
+    {
+        _id: "prod1",
+        name: "Wireless Bluetooth Headphones",
+        description: "High-quality wireless headphones with noise cancellation",
+        category: "Electronics",
+        brand: "AudioTech",
+        price: 199.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 150,
+        sku: "AT-WBH-001",
+        specifications: {
+            batteryLife: "30 hours",
+            connectivity: ["Bluetooth 5.0", "USB-C"],
+            weight: "250g",
+            color: "Black"
+        },
+        ratings: {
+            average: 4.5,
+            totalReviews: 1247
+        },
+        tags: ["wireless", "bluetooth", "noise-cancellation"],
+        createdAt: new Date("2024-01-10T08:00:00Z"),
+        updatedAt: new Date("2024-06-15T12:30:00Z")
+    },
+    {
+        _id: "prod2",
+        name: "Organic Coffee Beans",
+        description: "Premium organic coffee beans from Colombia",
+        category: "Food & Beverages",
+        brand: "Mountain Roast",
+        price: 24.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 500,
+        sku: "MR-OCB-500",
+        specifications: {
+            origin: "Colombia",
+            roastLevel: "Medium",
+            weight: "500g",
+            organic: true
+        },
+        ratings: {
+            average: 4.8,
+            totalReviews: 892
+        },
+        tags: ["organic", "coffee", "fair-trade"],
+        createdAt: new Date("2024-02-05T10:15:00Z"),
+        updatedAt: new Date("2024-06-10T09:20:00Z")
+    },
+    {
+        _id: "prod3",
+        name: "Smart Fitness Watch",
+        description: "Advanced fitness tracker with heart rate monitoring and GPS",
+        category: "Electronics",
+        brand: "FitTrack",
+        price: 299.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 75,
+        sku: "FT-SFW-002",
+        specifications: {
+            batteryLife: "7 days",
+            waterResistance: "50m",
+            sensors: ["Heart Rate", "GPS", "Accelerometer", "Gyroscope"],
+            compatibility: ["iOS", "Android"]
+        },
+        ratings: {
+            average: 4.3,
+            totalReviews: 654
+        },
+        tags: ["fitness", "smartwatch", "gps", "health"],
+        createdAt: new Date("2024-03-20T14:30:00Z"),
+        updatedAt: new Date("2024-06-18T16:45:00Z")
+    },
+    {
+        _id: "prod4",
+        name: "Eco-Friendly Water Bottle",
+        description: "Sustainable stainless steel water bottle with temperature retention",
+        category: "Lifestyle",
+        brand: "EcoBottle",
+        price: 29.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 300,
+        sku: "EB-EFWB-750",
+        specifications: {
+            material: "Stainless Steel",
+            capacity: "750ml",
+            insulation: "Double-wall vacuum",
+            hotRetention: "12 hours",
+            coldRetention: "24 hours"
+        },
+        ratings: {
+            average: 4.6,
+            totalReviews: 445
+        },
+        tags: ["eco-friendly", "stainless-steel", "insulated"],
+        createdAt: new Date("2024-04-15T11:00:00Z"),
+        updatedAt: new Date("2024-06-12T13:30:00Z")
+    },
+    {
+        _id: "prod5",
+        name: "Professional Camera Lens",
+        description: "High-quality 85mm portrait lens for professional photography",
+        category: "Photography",
+        brand: "LensMaster",
+        price: 899.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 25,
+        sku: "LM-PCL-85",
+        specifications: {
+            focalLength: "85mm",
+            aperture: "f/1.4",
+            mount: "Canon EF",
+            weight: "950g",
+            elements: "11 elements in 8 groups"
+        },
+        ratings: {
+            average: 4.9,
+            totalReviews: 178
+        },
+        tags: ["photography", "lens", "portrait", "professional"],
+        createdAt: new Date("2024-05-01T09:30:00Z"),
+        updatedAt: new Date("2024-06-20T15:15:00Z")
+    }
+]);
+
+print("Created " + db.products.countDocuments() + " products in the products collection");
+
+// Create indexes for better query performance
+db.products.createIndex({ "category": 1 });
+db.products.createIndex({ "brand": 1 });
+db.products.createIndex({ "price": 1 });
+db.products.createIndex({ "tags": 1 });
+db.products.createIndex({ "sku": 1 }, { unique: true });
+
+print("Created indexes on products collection");

--- a/sample-data/03-orders.js
+++ b/sample-data/03-orders.js
@@ -1,0 +1,177 @@
+// Initialize orders collection with sample data
+print("Initializing orders collection...");
+
+// Switch to the sampledb database
+use('sampledb');
+
+// Create orders collection and insert sample orders
+db.orders.insertMany([
+    {
+        _id: "order1",
+        orderNumber: "ORD-2024-001",
+        userId: "user1",
+        customerInfo: {
+            email: "alice.smith@example.com",
+            firstName: "Alice",
+            lastName: "Smith"
+        },
+        items: [
+            {
+                productId: "prod1",
+                productName: "Wireless Bluetooth Headphones",
+                quantity: 1,
+                unitPrice: 199.99,
+                totalPrice: 199.99
+            },
+            {
+                productId: "prod4",
+                productName: "Eco-Friendly Water Bottle",
+                quantity: 2,
+                unitPrice: 29.99,
+                totalPrice: 59.98
+            }
+        ],
+        orderSummary: {
+            subtotal: 259.97,
+            tax: 20.80,
+            shipping: 9.99,
+            total: 290.76
+        },
+        status: "delivered",
+        paymentMethod: "credit_card",
+        shippingAddress: {
+            street: "123 Main St",
+            city: "Seattle",
+            state: "WA",
+            postalCode: "98101",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-01T10:30:00Z"),
+        shippedDate: new Date("2024-06-02T14:15:00Z"),
+        deliveredDate: new Date("2024-06-05T16:20:00Z")
+    },
+    {
+        _id: "order2",
+        orderNumber: "ORD-2024-002",
+        userId: "user2",
+        customerInfo: {
+            email: "bob.jones@example.com",
+            firstName: "Bob",
+            lastName: "Jones"
+        },
+        items: [
+            {
+                productId: "prod2",
+                productName: "Organic Coffee Beans",
+                quantity: 3,
+                unitPrice: 24.99,
+                totalPrice: 74.97
+            }
+        ],
+        orderSummary: {
+            subtotal: 74.97,
+            tax: 6.00,
+            shipping: 5.99,
+            total: 86.96
+        },
+        status: "shipped",
+        paymentMethod: "paypal",
+        shippingAddress: {
+            street: "456 Oak Ave",
+            city: "San Francisco",
+            state: "CA",
+            postalCode: "94102",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-10T15:45:00Z"),
+        shippedDate: new Date("2024-06-11T09:30:00Z")
+    },
+    {
+        _id: "order3",
+        orderNumber: "ORD-2024-003",
+        userId: "user4",
+        customerInfo: {
+            email: "david.lee@example.com",
+            firstName: "David",
+            lastName: "Lee"
+        },
+        items: [
+            {
+                productId: "prod3",
+                productName: "Smart Fitness Watch",
+                quantity: 1,
+                unitPrice: 299.99,
+                totalPrice: 299.99
+            },
+            {
+                productId: "prod4",
+                productName: "Eco-Friendly Water Bottle",
+                quantity: 1,
+                unitPrice: 29.99,
+                totalPrice: 29.99
+            }
+        ],
+        orderSummary: {
+            subtotal: 329.98,
+            tax: 26.40,
+            shipping: 0.00,
+            total: 356.38
+        },
+        status: "processing",
+        paymentMethod: "credit_card",
+        shippingAddress: {
+            street: "789 Pine St",
+            city: "Austin",
+            state: "TX",
+            postalCode: "73301",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-18T12:15:00Z")
+    },
+    {
+        _id: "order4",
+        orderNumber: "ORD-2024-004",
+        userId: "user5",
+        customerInfo: {
+            email: "eve.brown@example.com",
+            firstName: "Eve",
+            lastName: "Brown"
+        },
+        items: [
+            {
+                productId: "prod5",
+                productName: "Professional Camera Lens",
+                quantity: 1,
+                unitPrice: 899.99,
+                totalPrice: 899.99
+            }
+        ],
+        orderSummary: {
+            subtotal: 899.99,
+            tax: 72.00,
+            shipping: 15.99,
+            total: 987.98
+        },
+        status: "pending",
+        paymentMethod: "bank_transfer",
+        shippingAddress: {
+            street: "321 Cedar Blvd",
+            city: "Portland",
+            state: "OR",
+            postalCode: "97201",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-20T14:30:00Z")
+    }
+]);
+
+print("Created " + db.orders.countDocuments() + " orders in the orders collection");
+
+// Create indexes for better query performance
+db.orders.createIndex({ "userId": 1 });
+db.orders.createIndex({ "orderNumber": 1 }, { unique: true });
+db.orders.createIndex({ "status": 1 });
+db.orders.createIndex({ "orderDate": 1 });
+db.orders.createIndex({ "customerInfo.email": 1 });
+
+print("Created indexes on orders collection");

--- a/sample-data/04-analytics.js
+++ b/sample-data/04-analytics.js
@@ -1,0 +1,88 @@
+// Initialize analytics collection with sample data
+print("Initializing analytics collection...");
+
+// Switch to the sampledb database
+use('sampledb');
+
+// Create analytics collection and insert sample analytics data
+db.analytics.insertMany([
+    {
+        _id: "analytics_2024_06",
+        period: "2024-06",
+        type: "monthly_summary",
+        metrics: {
+            totalUsers: 5,
+            activeUsers: 4,
+            newUsers: 2,
+            totalOrders: 4,
+            totalRevenue: 1721.08,
+            averageOrderValue: 430.27,
+            topSellingProducts: [
+                { productId: "prod5", productName: "Professional Camera Lens", quantitySold: 1, revenue: 899.99 },
+                { productId: "prod1", productName: "Wireless Bluetooth Headphones", quantitySold: 1, revenue: 199.99 },
+                { productId: "prod3", productName: "Smart Fitness Watch", quantitySold: 1, revenue: 299.99 }
+            ],
+            categoryBreakdown: [
+                { category: "Electronics", orders: 2, revenue: 499.98 },
+                { category: "Photography", orders: 1, revenue: 899.99 },
+                { category: "Food & Beverages", orders: 1, revenue: 74.97 },
+                { category: "Lifestyle", orders: 3, revenue: 119.96 }
+            ]
+        },
+        generatedAt: new Date("2024-07-01T00:00:00Z")
+    },
+    {
+        _id: "user_activity_2024_06_20",
+        date: "2024-06-20",
+        type: "daily_user_activity",
+        activities: [
+            {
+                userId: "user1",
+                actions: [
+                    { action: "login", timestamp: new Date("2024-06-20T08:30:00Z") },
+                    { action: "view_product", productId: "prod2", timestamp: new Date("2024-06-20T08:35:00Z") },
+                    { action: "view_orders", timestamp: new Date("2024-06-20T08:40:00Z") }
+                ]
+            },
+            {
+                userId: "user5",
+                actions: [
+                    { action: "login", timestamp: new Date("2024-06-20T14:15:00Z") },
+                    { action: "view_product", productId: "prod5", timestamp: new Date("2024-06-20T14:20:00Z") },
+                    { action: "add_to_cart", productId: "prod5", timestamp: new Date("2024-06-20T14:25:00Z") },
+                    { action: "place_order", orderId: "order4", timestamp: new Date("2024-06-20T14:30:00Z") }
+                ]
+            }
+        ]
+    }
+]);
+
+print("Created " + db.analytics.countDocuments() + " analytics records");
+
+// Create indexes for analytics queries
+db.analytics.createIndex({ "period": 1 });
+db.analytics.createIndex({ "type": 1 });
+db.analytics.createIndex({ "date": 1 });
+
+print("Created indexes on analytics collection");
+
+// Create some aggregation views for common queries
+print("Setting up sample aggregation examples...");
+
+// Example aggregation: User order summary
+print("Sample aggregation - User order summary:");
+db.orders.aggregate([
+    {
+        $group: {
+            _id: "$userId",
+            totalOrders: { $sum: 1 },
+            totalSpent: { $sum: "$orderSummary.total" },
+            averageOrderValue: { $avg: "$orderSummary.total" }
+        }
+    },
+    {
+        $sort: { totalSpent: -1 }
+    }
+]).forEach(printjson);
+
+print("Sample data initialization completed!");

--- a/sample-data/README.md
+++ b/sample-data/README.md
@@ -1,0 +1,55 @@
+# Sample Data for DocumentDB
+
+This directory contains sample JavaScript files that initialize a DocumentDB instance with demo data. The data represents a simple e-commerce application with users, products, orders, and analytics.
+
+## Collections Created
+
+### 1. Users Collection (`01-users.js`)
+Contains sample user accounts with the following structure:
+- User profiles with personal information
+- Preferences and settings
+- Tags for categorization
+- Indexed on email, username, city, and tags
+
+### 2. Products Collection (`02-products.js`)
+Contains sample product catalog with:
+- Electronics, lifestyle, food, and photography items
+- Detailed specifications and pricing
+- Ratings and reviews data
+- Indexed on category, brand, price, tags, and SKU
+
+### 3. Orders Collection (`03-orders.js`)
+Contains sample order data including:
+- Order details and customer information
+- Line items with product references
+- Order status tracking
+- Shipping and payment information
+- Indexed on userId, orderNumber, status, orderDate, and customer email
+
+### 4. Analytics Collection (`04-analytics.js`)
+Contains sample analytics and reporting data:
+- Monthly summary metrics
+- Daily user activity logs
+- Product performance data
+- Sample aggregation examples
+
+## Database Structure
+
+All sample data is inserted into the `sampledb` database to keep it separate from any existing data.
+
+## Usage
+
+These files are automatically executed when the DocumentDB container starts with the `--init-data=true` flag. They can also be run manually using mongosh:
+
+```bash
+mongosh localhost:10260 -u username -p mypassword --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --file 01-users.js
+```
+
+## Data Overview
+
+- **5 users** with diverse profiles and preferences
+- **5 products** across different categories
+- **4 orders** in various stages (pending, processing, shipped, delivered)
+- **2 analytics records** with sample metrics and user activity
+
+This sample data provides a foundation for testing queries, exploring DocumentDB features, and building applications.

--- a/scripts/build_and_start_gateway.sh
+++ b/scripts/build_and_start_gateway.sh
@@ -149,4 +149,9 @@ if [ -z "$configFile" ]; then
     ./target/release-with-symbols/documentdb_gateway
 else
     ./target/release-with-symbols/documentdb_gateway "$configFile"
-fi
+fi &
+
+gateway_pid=$!
+
+# Wait for the gateway process to keep the script alive
+wait $gateway_pid

--- a/scripts/emulator_entrypoint.sh
+++ b/scripts/emulator_entrypoint.sh
@@ -97,6 +97,16 @@ Optional arguments:
                         Allow external connections to PostgreSQL.
                         Defaults to false.
                         Overrides ALLOW_EXTERNAL_CONNECTIONS environment variable.
+  --init-data-path [PATH]
+                        Specify a directory containing JavaScript files for database initialization.
+                        Files will be executed in alphabetical order using mongosh.
+                        When this option is used, --init-data is automatically set to false.
+                        Defaults to /init_doc_db.d
+                        Overrides INIT_DATA_PATH environment variable.
+  --init-data           Enable initialization with built-in sample data.
+                        Creates sample collections (users, products, orders, analytics) in 'sampledb' database.
+                        Defaults to false.
+                        Overrides INIT_DATA environment variable.
                         
 EOF
 }
@@ -183,6 +193,16 @@ do
         export ALLOW_EXTERNAL_CONNECTIONS=$1
         shift;;
 
+    --init-data-path)
+        shift
+        export INIT_DATA_PATH=$1
+        export INIT_DATA=false  # Disable built-in sample data when custom path is provided
+        shift;;
+
+    --init-data)
+        export INIT_DATA=true
+        shift;;
+
     -*)
         echo "Unknown option $1"
         exit 1;; 
@@ -198,6 +218,8 @@ export USERNAME=${USERNAME:-default_user}
 export PASSWORD=${PASSWORD:-Admin100}
 export CREATE_USER=${CREATE_USER:-true}
 export START_POSTGRESQL=${START_POSTGRESQL:-true}
+export INIT_DATA_PATH=${INIT_DATA_PATH:-/init_doc_db.d}
+export INIT_DATA=${INIT_DATA:-false}
 
 # Setup centralized log directory structure
 echo "Setting up centralized log directory at /var/log/documentdb..."
@@ -260,6 +282,13 @@ if [ -n "$LOG_LEVEL" ] && \
    [ "$LOG_LEVEL" != "debug" ] && \
    [ "$LOG_LEVEL" != "trace" ]; then
     echo "Invalid log level value $LOG_LEVEL, must be one of: quiet, error, warn, info, debug, trace"
+    exit 1
+fi
+
+if [ -n "$INIT_DATA" ] && \
+   [ "$INIT_DATA" != "true" ] && \
+   [ "$INIT_DATA" != "false" ]; then
+    echo "Invalid init-data value $INIT_DATA, must be true or false"
     exit 1
 fi
 
@@ -384,6 +413,85 @@ fi
 
 gateway_pid=$! # Capture the PID of the gateway process
 
+# Wait for the gateway to be ready before attempting initialization
+echo "Waiting for gateway to be ready..."
+max_attempts=60
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+    if nc -z localhost "$DOCUMENTDB_PORT"; then
+        echo "Gateway is ready on localhost:$DOCUMENTDB_PORT"
+        break
+    fi
+    echo "Attempt $((attempt + 1))/$max_attempts: Gateway not ready yet, waiting..."
+    sleep 1
+    attempt=$((attempt + 1))
+done
+
+if [ $attempt -eq $max_attempts ]; then
+    echo "Error: Gateway failed to start within $max_attempts seconds"
+    exit 1
+fi
+
+# Initialize database with custom data if directory exists and contains JS files
+custom_data_initialized=false
+if [ -d "$INIT_DATA_PATH" ] && [ "$(ls -A "$INIT_DATA_PATH"/*.js 2>/dev/null)" ]; then
+    echo "Initializing database with custom data from: $INIT_DATA_PATH"
+    
+    # Use the dedicated initialization script
+    init_script="/home/documentdb/gateway/scripts/init_documentdb_data.sh"
+    if [ -f "$init_script" ]; then
+        echo "Using custom initialization data from: $INIT_DATA_PATH"
+        if "$init_script" -H localhost -P "$DOCUMENTDB_PORT" -u "$USERNAME" -p "$PASSWORD" -d "$INIT_DATA_PATH" -v; then
+            echo "Custom data initialization completed."
+            custom_data_initialized=true
+        else
+            echo "Error: Custom data initialization failed"
+            exit 1
+        fi
+    else
+        echo "Warning: Initialization script not found at $init_script"
+    fi
+fi
+
+# Initialize database with sample data if enabled
+if [ "$INIT_DATA" = "true" ]; then
+    echo "Initializing database with built-in sample data..."
+    
+    # Use the sample data directory
+    sample_data_path="/home/documentdb/gateway/sample-data"
+    init_script="/home/documentdb/gateway/scripts/init_documentdb_data.sh"
+    
+    if [ -f "$init_script" ] && [ -d "$sample_data_path" ]; then
+        echo "Loading sample data from: $sample_data_path"
+        if "$init_script" -H localhost -P "$DOCUMENTDB_PORT" -u "$USERNAME" -p "$PASSWORD" -d "$sample_data_path" -v; then
+            echo "Sample data initialization completed."
+        else
+            echo "Error: Sample data initialization failed"
+            exit 1
+        fi
+        echo ""
+        echo "Sample data has been loaded into the 'sampledb' database with the following collections:"
+        echo "  - users (5 sample users)"
+        echo "  - products (5 sample products)"  
+        echo "  - orders (4 sample orders)"
+        echo "  - analytics (sample metrics and activity data)"
+        echo ""
+        echo "Connect to your DocumentDB instance and use: use('sampledb')"
+    else
+        echo "Warning: Sample data or initialization script not found"
+        if [ ! -f "$init_script" ]; then
+            echo "  - Missing: $init_script"
+        fi
+        if [ ! -d "$sample_data_path" ]; then
+            echo "  - Missing: $sample_data_path"
+        fi
+    fi
+fi
+
+if [ "$custom_data_initialized" = "false" ] && [ "$INIT_DATA" = "false" ]; then
+    echo "No initialization data loaded. Use --init-data-path to provide custom initialization scripts"
+    echo "or --init-data to load built-in sample data."
+fi
 # Also stream existing gateway logs (for historical logs that might already exist)
 if [ -f "$GATEWAY_LOG" ]; then
     echo "Starting gateway log streaming for existing logs..."

--- a/scripts/init_documentdb_data.sh
+++ b/scripts/init_documentdb_data.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+# DocumentDB Data Initialization Script
+# This script initializes DocumentDB with data from JavaScript files
+
+set -e
+set -u
+
+# Default values
+USERNAME="default_user"
+PASSWORD=""
+INIT_DATA_PATH="/init_doc_db.d"
+VERBOSE="false"
+DOCUMENTDB_PORT="10260"
+LOG_FILE="${ENTRYPOINT_LOG:-/var/log/documentdb/gateway_entrypoint.log}"
+LOG_FILE_AVAILABLE="false"
+
+if [ -n "$LOG_FILE" ]; then
+    if touch "$LOG_FILE" 2>/dev/null; then
+        LOG_FILE_AVAILABLE="true"
+    else
+        echo "Warning: Unable to append to log file: $LOG_FILE"
+    fi
+fi
+
+# Print usage information
+usage() {
+    cat << EOF
+DocumentDB Data Initialization Script
+
+Usage: $0 [OPTIONS]
+
+Options:
+  -h, --help                    Show this help message
+  -H, --host HOST              DocumentDB host (default: localhost)
+  -P, --port PORT              DocumentDB port (default: 10260)
+  -u, --username USERNAME      DocumentDB username (default: default_user)
+  -p, --password PASSWORD      DocumentDB password (required)
+  -d, --data-path PATH         Path to directory containing .js initialization files
+                               (default: /init_doc_db.d)
+  -v, --verbose                Enable verbose output
+
+Examples:
+  # Initialize with custom data files
+  $0 -p mypassword -d /path/to/init/scripts
+
+  # Initialize with specific host and port
+  $0 -H myhost -P 27017 -u myuser -p mypassword -d /custom/path
+
+EOF
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -H|--host)
+            DOCUMENTDB_HOST="$2"
+            shift 2
+            ;;
+        -P|--port)
+            DOCUMENTDB_PORT="$2"
+            shift 2
+            ;;
+        -u|--username)
+            USERNAME="$2"
+            shift 2
+            ;;
+        -p|--password)
+            PASSWORD="$2"
+            shift 2
+            ;;
+        -d|--data-path)
+            INIT_DATA_PATH="$2"
+            shift 2
+            ;;
+        -v|--verbose)
+            VERBOSE="true"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [ -z "$PASSWORD" ]; then
+    echo "Error: Password is required. Use -p or --password to specify the password."
+    exit 1
+fi
+
+# Verbose logging function
+log() {
+    if [ "$VERBOSE" = "true" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+    fi
+}
+
+print_and_log() {
+    local message="$1"
+    echo "$message"
+    if [ "$LOG_FILE_AVAILABLE" = "true" ]; then
+        printf '%s\n' "$message" >> "$LOG_FILE"
+    fi
+}
+
+print_file_and_log() {
+    local file_path="$1"
+    if [ "$LOG_FILE_AVAILABLE" = "true" ]; then
+        tee -a "$LOG_FILE" < "$file_path"
+    else
+        cat "$file_path"
+    fi
+}
+
+# Function to wait for DocumentDB to be ready
+wait_for_documentdb() {
+    local max_attempts=30
+    local attempt=1
+    
+    echo "Waiting for DocumentDB to be ready at localhost:${DOCUMENTDB_PORT}..."
+    
+    while [ $attempt -le $max_attempts ]; do
+        if command -v mongosh >/dev/null 2>&1; then
+            if mongosh "localhost:${DOCUMENTDB_PORT}" -u "$USERNAME" -p "$PASSWORD" --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.runCommand({ping: 1})" >/dev/null 2>&1; then
+                echo "DocumentDB is ready!"
+                return 0
+            fi
+        else
+            echo "Warning: mongosh not found. Cannot verify DocumentDB readiness."
+            return 1
+        fi
+        
+        log "Attempt $attempt/$max_attempts failed, waiting..."
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+    
+    echo "Error: DocumentDB did not become ready within $(($max_attempts * 2)) seconds"
+    return 1
+}
+
+# Function to execute initialization scripts from a directory
+run_init_scripts() {
+    local init_dir="$1"
+    local script_count=0
+    
+    if [ ! -d "$init_dir" ]; then
+        echo "Error: Initialization directory not found: $init_dir"
+        return 1
+    fi
+    
+    echo "Processing initialization scripts from: $init_dir"
+    
+    # Check if mongosh is available
+    if ! command -v mongosh >/dev/null 2>&1; then
+        echo "Error: mongosh not found. Please install mongosh to run initialization scripts."
+        return 1
+    fi
+    
+    # Process .js files in alphabetical order
+    for init_file in "$init_dir"/*.js; do
+        if [ -f "$init_file" ]; then
+            script_count=$((script_count + 1))
+            echo "Executing initialization script: $(basename "$init_file")"
+            log "Full path: $init_file"
+            print_and_log "---- Begin init data: $(basename \"$init_file\") ----"
+            print_file_and_log "$init_file"
+            print_and_log "---- End init data: $(basename \"$init_file\") ----"
+
+            if mongosh "localhost:${DOCUMENTDB_PORT}" -u "$USERNAME" -p "$PASSWORD" --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --file "$init_file"; then
+                log "Successfully executed: $(basename "$init_file")"
+            else
+                echo "Error: Failed to execute: $(basename "$init_file")"
+                echo "This indicates invalid JavaScript syntax or operation error."
+                return 1
+            fi
+        fi
+    done
+    
+    if [ $script_count -eq 0 ]; then
+        echo "No JavaScript files found in: $init_dir"
+        return 1
+    fi
+    
+    echo "Processed $script_count initialization script(s)"
+    
+    # Log completion message that the test script can monitor
+    echo "Sample data initialization completed!"
+    return 0
+}
+
+# Main initialization logic
+main() {
+    echo "Starting DocumentDB data initialization..."
+    echo "Host: localhost:${DOCUMENTDB_PORT}"
+    echo "Username: $USERNAME"
+    
+    # Wait for DocumentDB to be ready
+    if ! wait_for_documentdb; then
+        exit 1
+    fi
+    
+    # Use custom initialization data
+    echo "Using custom initialization data from: $INIT_DATA_PATH"
+    if ! run_init_scripts "$INIT_DATA_PATH"; then
+        echo "Error: Failed to process custom initialization data"
+        exit 1
+    fi
+    
+    echo "Database initialization completed successfully!"
+}
+
+# Run the main function
+main

--- a/test-init-data/sample-invalid-data/01-syntax-errors.js
+++ b/test-init-data/sample-invalid-data/01-syntax-errors.js
@@ -1,0 +1,37 @@
+// Sample invalid JavaScript file for testing error handling
+print("This file contains syntax errors and will cause initialization to fail");
+
+use('test');
+
+// Error 1: Missing closing quote
+db.users.insertMany([
+    {
+        _id: "user1",
+        username: "alice_smith",
+        email: "alice.smith@example.com,  // Missing closing quote here
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 28
+    }
+]);
+
+// Error 2: Missing closing bracket
+db.products.insertMany([
+    {
+        _id: "product1",
+        name: "Test Product",
+        price: 29.99
+    // Missing closing bracket here
+]);
+
+// Error 3: Invalid function call
+this_function_does_not_exist();
+
+// Error 4: Invalid field name
+db.orders.insertOne({
+    _id: "order1",
+    $invalid_field: "This field name is invalid because it starts with $",
+    customer: "user1"
+});
+
+print("This line will never be reached due to the errors above");

--- a/test-init-data/sample-invalid-data/02-mongodb-errors.js
+++ b/test-init-data/sample-invalid-data/02-mongodb-errors.js
@@ -1,0 +1,44 @@
+// Sample invalid JavaScript file for testing MongoDB operation errors
+print("This file contains MongoDB operation errors");
+
+use('test');
+
+// First, insert a valid document
+db.users.insertOne({
+    _id: "user1",
+    username: "alice_smith",
+    email: "alice.smith@example.com",
+    firstName: "Alice",
+    lastName: "Smith",
+    age: 28
+});
+
+print("First user inserted successfully");
+
+// Now try to insert a duplicate _id - this should fail
+db.users.insertOne({
+    _id: "user1",  // This will cause a duplicate key error
+    username: "duplicate_user",
+    email: "duplicate@example.com",
+    firstName: "Duplicate",
+    lastName: "User",
+    age: 30
+});
+
+print("This line should not be reached due to the duplicate key error above");
+
+// Additional operations that won't be executed due to the error
+db.products.insertMany([
+    {
+        _id: "product1",
+        name: "Test Product",
+        price: 29.99
+    },
+    {
+        _id: "product2", 
+        name: "Another Product",
+        price: 39.99
+    }
+]);
+
+print("Product insertion completed - this won't be printed");

--- a/test-init-data/sample-invalid-data/03-runtime-errors.js
+++ b/test-init-data/sample-invalid-data/03-runtime-errors.js
@@ -1,0 +1,36 @@
+// Sample invalid JavaScript file for testing runtime errors
+print("This file contains runtime errors");
+
+use('test');
+
+// Insert a valid document first
+db.users.insertOne({
+    _id: "user1",
+    username: "alice_smith",
+    email: "alice.smith@example.com",
+    firstName: "Alice",
+    lastName: "Smith",
+    age: 28
+});
+
+print("First user inserted successfully");
+
+// Cause a runtime error by accessing an undefined variable
+print("Trying to access undefined variable: " + undefined_variable_name);
+
+// This code will not be reached due to the runtime error above
+db.users.insertOne({
+    _id: "user2",
+    username: "bob_jones",
+    email: "bob.jones@example.com",
+    firstName: "Bob",
+    lastName: "Jones",
+    age: 35
+});
+
+print("This line will never be reached due to the runtime error above");
+
+// Try to call a method that doesn't exist
+db.nonExistentCollection.nonExistentMethod();
+
+print("This line also won't be reached");

--- a/test-init-data/test-init-data/01-users.js
+++ b/test-init-data/test-init-data/01-users.js
@@ -1,0 +1,87 @@
+// Initialize users collection with sample data
+print("Initializing users collection...");
+
+// Switch to the test database
+use('test');
+
+// Create users collection and insert sample users
+db.users.insertMany([
+    {
+        _id: "user1",
+        username: "alice_smith",
+        email: "alice.smith@example.com",
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 28,
+        city: "Seattle",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-01-15T10:30:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: true,
+            theme: "dark"
+        },
+        tags: ["premium", "early_adopter"]
+    },
+    {
+        _id: "user2",
+        username: "bob_jones",
+        email: "bob.jones@example.com",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 35,
+        city: "San Francisco",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-02-20T14:15:00Z"),
+        preferences: {
+            newsletter: false,
+            notifications: true,
+            theme: "light"
+        },
+        tags: ["standard"]
+    },
+    {
+        _id: "user3",
+        username: "carol_wilson",
+        email: "carol.wilson@example.com",
+        firstName: "Carol",
+        lastName: "Wilson",
+        age: 42,
+        city: "New York",
+        country: "USA",
+        isActive: false,
+        createdAt: new Date("2024-03-10T09:45:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: false,
+            theme: "light"
+        },
+        tags: ["premium", "vip"]
+    },
+    {
+        _id: "user4",
+        username: "david_lee",
+        email: "david.lee@example.com",
+        firstName: "David",
+        lastName: "Lee",
+        age: 31,
+        city: "Austin",
+        country: "USA",
+        isActive: true,
+        createdAt: new Date("2024-04-05T16:20:00Z"),
+        preferences: {
+            newsletter: true,
+            notifications: true,
+            theme: "dark"
+        },
+        tags: ["standard", "developer"]
+    }
+]);
+
+print("Created " + db.users.countDocuments() + " users in the users collection");
+
+// Create an index on email for faster queries
+db.users.createIndex({ "email": 1 });
+print("Created index on email field");

--- a/test-init-data/test-init-data/02-products.js
+++ b/test-init-data/test-init-data/02-products.js
@@ -1,0 +1,117 @@
+// Initialize products collection with sample data
+print("Initializing products collection...");
+
+// Switch to the test database
+use('test');
+
+// Create products collection and insert sample products
+db.products.insertMany([
+    {
+        _id: "prod1",
+        name: "Wireless Bluetooth Headphones",
+        description: "High-quality wireless headphones with noise cancellation",
+        category: "Electronics",
+        brand: "AudioTech",
+        price: 199.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 150,
+        sku: "AT-WBH-001",
+        specifications: {
+            batteryLife: "30 hours",
+            connectivity: ["Bluetooth 5.0", "USB-C"],
+            weight: "250g",
+            color: "Black"
+        },
+        ratings: {
+            average: 4.5,
+            totalReviews: 1247
+        },
+        tags: ["wireless", "bluetooth", "noise-cancellation"],
+        createdAt: new Date("2024-01-10T08:00:00Z"),
+        updatedAt: new Date("2024-06-15T12:30:00Z")
+    },
+    {
+        _id: "prod2",
+        name: "Organic Coffee Beans",
+        description: "Premium organic coffee beans from Colombia",
+        category: "Food & Beverages",
+        brand: "Mountain Roast",
+        price: 24.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 500,
+        sku: "MR-OCB-500",
+        specifications: {
+            origin: "Colombia",
+            roastLevel: "Medium",
+            weight: "500g",
+            organic: true
+        },
+        ratings: {
+            average: 4.8,
+            totalReviews: 892
+        },
+        tags: ["organic", "coffee", "fair-trade"],
+        createdAt: new Date("2024-02-01T10:15:00Z"),
+        updatedAt: new Date("2024-06-20T09:45:00Z")
+    },
+    {
+        _id: "prod3",
+        name: "Smart Fitness Watch",
+        description: "Advanced fitness tracker with heart rate monitoring",
+        category: "Electronics",
+        brand: "FitTech",
+        price: 299.99,
+        currency: "USD",
+        inStock: false,
+        stockQuantity: 0,
+        sku: "FT-SFW-PRO",
+        specifications: {
+            display: "1.4 inch AMOLED",
+            batteryLife: "7 days",
+            waterproof: "5ATM",
+            sensors: ["Heart Rate", "GPS", "Accelerometer"]
+        },
+        ratings: {
+            average: 4.3,
+            totalReviews: 567
+        },
+        tags: ["fitness", "smartwatch", "health"],
+        createdAt: new Date("2024-03-15T14:20:00Z"),
+        updatedAt: new Date("2024-07-01T11:00:00Z")
+    },
+    {
+        _id: "prod4",
+        name: "Eco-Friendly Water Bottle",
+        description: "Reusable stainless steel water bottle",
+        category: "Home & Garden",
+        brand: "EcoLife",
+        price: 29.99,
+        currency: "USD",
+        inStock: true,
+        stockQuantity: 300,
+        sku: "EL-EFWB-750",
+        specifications: {
+            material: "Stainless Steel",
+            capacity: "750ml",
+            insulation: "Double Wall",
+            bpaFree: true
+        },
+        ratings: {
+            average: 4.6,
+            totalReviews: 324
+        },
+        tags: ["eco-friendly", "reusable", "steel"],
+        createdAt: new Date("2024-04-01T09:30:00Z"),
+        updatedAt: new Date("2024-06-10T15:45:00Z")
+    }
+]);
+
+print("Created " + db.products.countDocuments() + " products in the products collection");
+
+// Create indexes for better query performance
+db.products.createIndex({ "category": 1 });
+db.products.createIndex({ "price": 1 });
+db.products.createIndex({ "inStock": 1 });
+print("Created indexes on category, price, and inStock fields");

--- a/test-init-data/test-init-data/03-orders.js
+++ b/test-init-data/test-init-data/03-orders.js
@@ -1,0 +1,185 @@
+// Initialize orders collection with sample data
+print("Initializing orders collection...");
+
+// Switch to the test database
+use('test');
+
+// Create orders collection and insert sample orders
+db.orders.insertMany([
+    {
+        _id: "order1",
+        orderNumber: "ORD-2024-001",
+        userId: "user1",
+        customerInfo: {
+            email: "alice.smith@example.com",
+            firstName: "Alice",
+            lastName: "Smith"
+        },
+        items: [
+            {
+                productId: "prod1",
+                productName: "Wireless Bluetooth Headphones",
+                quantity: 1,
+                unitPrice: 199.99,
+                totalPrice: 199.99
+            },
+            {
+                productId: "prod4",
+                productName: "Eco-Friendly Water Bottle",
+                quantity: 2,
+                unitPrice: 29.99,
+                totalPrice: 59.98
+            }
+        ],
+        subtotal: 259.97,
+        tax: 20.80,
+        shipping: 9.99,
+        total: 290.76,
+        currency: "USD",
+        status: "completed",
+        paymentMethod: "credit_card",
+        shippingAddress: {
+            street: "123 Main St",
+            city: "Seattle",
+            state: "WA",
+            zipCode: "98101",
+            country: "USA"
+        },
+        orderDate: new Date("2024-05-01T10:30:00Z"),
+        shippedDate: new Date("2024-05-02T14:20:00Z"),
+        deliveredDate: new Date("2024-05-05T16:45:00Z")
+    },
+    {
+        _id: "order2",
+        orderNumber: "ORD-2024-002",
+        userId: "user2",
+        customerInfo: {
+            email: "bob.jones@example.com",
+            firstName: "Bob",
+            lastName: "Jones"
+        },
+        items: [
+            {
+                productId: "prod2",
+                productName: "Organic Coffee Beans",
+                quantity: 3,
+                unitPrice: 24.99,
+                totalPrice: 74.97
+            }
+        ],
+        subtotal: 74.97,
+        tax: 6.00,
+        shipping: 5.99,
+        total: 86.96,
+        currency: "USD",
+        status: "shipped",
+        paymentMethod: "paypal",
+        shippingAddress: {
+            street: "456 Oak Ave",
+            city: "San Francisco",
+            state: "CA",
+            zipCode: "94102",
+            country: "USA"
+        },
+        orderDate: new Date("2024-05-15T09:15:00Z"),
+        shippedDate: new Date("2024-05-16T11:30:00Z"),
+        deliveredDate: null
+    },
+    {
+        _id: "order3",
+        orderNumber: "ORD-2024-003",
+        userId: "user4",
+        customerInfo: {
+            email: "david.lee@example.com",
+            firstName: "David",
+            lastName: "Lee"
+        },
+        items: [
+            {
+                productId: "prod1",
+                productName: "Wireless Bluetooth Headphones",
+                quantity: 1,
+                unitPrice: 199.99,
+                totalPrice: 199.99
+            },
+            {
+                productId: "prod2",
+                productName: "Organic Coffee Beans",
+                quantity: 1,
+                unitPrice: 24.99,
+                totalPrice: 24.99
+            }
+        ],
+        subtotal: 224.98,
+        tax: 18.00,
+        shipping: 9.99,
+        total: 252.97,
+        currency: "USD",
+        status: "processing",
+        paymentMethod: "credit_card",
+        shippingAddress: {
+            street: "789 Pine St",
+            city: "Austin",
+            state: "TX",
+            zipCode: "78701",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-01T15:45:00Z"),
+        shippedDate: null,
+        deliveredDate: null
+    },
+    {
+        _id: "order4",
+        orderNumber: "ORD-2024-004",
+        userId: "user1",
+        customerInfo: {
+            email: "alice.smith@example.com",
+            firstName: "Alice",
+            lastName: "Smith"
+        },
+        items: [
+            {
+                productId: "prod4",
+                productName: "Eco-Friendly Water Bottle",
+                quantity: 1,
+                unitPrice: 29.99,
+                totalPrice: 29.99
+            }
+        ],
+        subtotal: 29.99,
+        tax: 2.40,
+        shipping: 4.99,
+        total: 37.38,
+        currency: "USD",
+        status: "cancelled",
+        paymentMethod: "credit_card",
+        shippingAddress: {
+            street: "123 Main St",
+            city: "Seattle",
+            state: "WA",
+            zipCode: "98101",
+            country: "USA"
+        },
+        orderDate: new Date("2024-06-10T12:20:00Z"),
+        shippedDate: null,
+        deliveredDate: null,
+        cancelledDate: new Date("2024-06-11T08:30:00Z"),
+        cancelReason: "Customer requested cancellation"
+    }
+]);
+
+print("Created " + db.orders.countDocuments() + " orders in the orders collection");
+
+// Create indexes for better query performance
+db.orders.createIndex({ "userId": 1 });
+db.orders.createIndex({ "status": 1 });
+db.orders.createIndex({ "orderDate": 1 });
+db.orders.createIndex({ "orderNumber": 1 }, { unique: true });
+print("Created indexes on userId, status, orderDate, and orderNumber fields");
+
+// Display summary statistics
+print("\n=== Database Initialization Summary ===");
+print("Users: " + db.users.countDocuments());
+print("Products: " + db.products.countDocuments());
+print("Orders: " + db.orders.countDocuments());
+print("========================================");

--- a/test-init-data/test_init_data.sh
+++ b/test-init-data/test_init_data.sh
@@ -1,0 +1,298 @@
+#!/bin/bash
+
+# Script to test the init-data-path feature of DocumentDB
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CONTAINER_NAME="documentdb-gateway-test"
+IMAGE_NAME="documentdb-gateway-test"
+INIT_DATA_DIR="$SCRIPT_DIR/test-init-data"
+DOCKERFILE_PATH="$PROJECT_ROOT/.github/containers/Build-Ubuntu/Dockerfile_gateway"
+DOCUMENTDB_PORT="10260"
+PASSWORD="TestPassword123"
+
+echo "=== DocumentDB Init-Data-Path Feature Test ==="
+echo "Project Root: $PROJECT_ROOT"
+echo "Script Directory: $SCRIPT_DIR"
+echo "Container: $CONTAINER_NAME"
+echo "Image: $IMAGE_NAME"
+echo "Init Data Directory: $INIT_DATA_DIR"
+echo "Dockerfile: $DOCKERFILE_PATH"
+echo "DocumentDB Port: $DOCUMENTDB_PORT"
+echo
+
+# Function to check if mongosh is available
+check_mongosh() {
+    echo "=== Checking Prerequisites ==="
+    if ! command -v mongosh >/dev/null 2>&1; then
+        echo "❌ Error: mongosh is not installed or not in PATH"
+        echo "Please install MongoDB Shell (mongosh) to run this test."
+        echo "Visit: https://docs.mongodb.com/mongodb-shell/install/"
+        exit 1
+    fi
+    echo "✅ mongosh is available: $(mongosh --version)"
+    echo
+}
+
+# Function to build the Docker image
+build_image() {
+    echo "=== Building Docker Image ==="
+    if [ ! -f "$DOCKERFILE_PATH" ]; then
+        echo "Error: Dockerfile not found at $DOCKERFILE_PATH"
+        exit 1
+    fi
+    
+    echo "Building image $IMAGE_NAME from $DOCKERFILE_PATH..."
+    docker build -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" "$PROJECT_ROOT" --no-cache
+    echo "✅ Image built successfully"
+    echo
+}
+
+# Function to cleanup previous runs
+cleanup() {
+    echo "Cleaning up previous containers..."
+    docker stop $CONTAINER_NAME 2>/dev/null || true
+    docker rm $CONTAINER_NAME 2>/dev/null || true
+}
+
+# Function to wait for DocumentDB to be ready
+wait_for_documentdb() {
+    echo "Waiting for DocumentDB to be ready..."
+    local max_attempts=30
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        if mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.runCommand({ping: 1})" >/dev/null 2>&1; then
+            echo "DocumentDB is ready!"
+            return 0
+        fi
+        
+        echo "Attempt $attempt/$max_attempts - waiting..."
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+    
+    echo "Error: DocumentDB did not become ready"
+    return 1
+}
+
+# Function to wait for sample data initialization to complete by monitoring logs
+wait_for_data_initialization() {
+    echo "Waiting for data initialization to complete..."
+    local max_attempts=120  # 6 minutes timeout for data initialization
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        # Check if the completion message appears in container logs
+        if docker logs $CONTAINER_NAME 2>&1 | grep -q "Sample data initialization completed!"; then
+            echo "✅ Data initialization completed!"
+            return 0
+        fi
+        
+        echo "Attempt $attempt/$max_attempts - waiting for data initialization completion log..."
+        sleep 3
+        attempt=$((attempt + 1))
+    done
+    
+    echo "❌ Error: Data initialization did not complete within timeout"
+    echo "=== Recent Container Logs ==="
+    docker logs --tail 20 $CONTAINER_NAME
+    return 1
+}
+
+# Function to verify the initialized data with comprehensive checks
+verify_data() {
+    echo "=== Verifying Initialized Data ==="
+    
+    # Check users collection
+    echo "Checking users collection..."
+    USER_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.users.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Users count: $USER_COUNT"
+    
+    # Check products collection
+    echo "Checking products collection..."
+    PRODUCT_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.products.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Products count: $PRODUCT_COUNT"
+    
+    # Check orders collection
+    echo "Checking orders collection..."
+    ORDER_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.orders.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Orders count: $ORDER_COUNT"
+    
+    # Show sample data from each collection
+    echo
+    echo "=== Sample Data ==="
+    echo "Sample user:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.users.findOne()" --quiet 2>/dev/null
+    
+    echo
+    echo "Sample product:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.products.findOne()" --quiet 2>/dev/null
+    
+    echo
+    echo "Sample order:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.orders.findOne()" --quiet 2>/dev/null
+    
+    # Verify indexes were created
+    echo
+    echo "=== Checking Indexes ==="
+    echo "Users indexes:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.users.getIndexes()" --quiet 2>/dev/null
+    
+    echo
+    echo "Products indexes:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.products.getIndexes()" --quiet 2>/dev/null
+    
+    echo
+    echo "Orders indexes:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.orders.getIndexes()" --quiet 2>/dev/null
+    
+    # Test some queries
+    echo
+    echo "=== Query Tests ==="
+    echo "Testing query: Users with age > 30"
+    ADULT_USERS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.users.countDocuments({age: {\$gt: 30}})" --quiet 2>/dev/null | tail -1)
+    echo "Adult users (age > 30): $ADULT_USERS"
+    
+    echo "Testing query: Products in stock"
+    IN_STOCK_PRODUCTS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.products.countDocuments({inStock: true})" --quiet 2>/dev/null | tail -1)
+    echo "Products in stock: $IN_STOCK_PRODUCTS"
+    
+    echo "Testing query: Completed orders"
+    COMPLETED_ORDERS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('test'); db.orders.countDocuments({status: 'completed'})" --quiet 2>/dev/null | tail -1)
+    echo "Completed orders: $COMPLETED_ORDERS"
+}
+
+# Main test execution
+main() {
+    # Check prerequisites
+    check_mongosh
+    
+    # Cleanup any previous test runs
+    cleanup
+    
+    # Build the Docker image
+    build_image
+    
+    # Verify init data files exist
+    if [ ! -d "$INIT_DATA_DIR" ]; then
+        echo "Error: Init data directory not found at $INIT_DATA_DIR"
+        exit 1
+    fi
+    
+    echo "Init data files found:"
+    ls -la "$INIT_DATA_DIR"/*.js
+    echo
+    
+    # Run the container with our test data mounted
+    echo "=== Starting DocumentDB Container ==="
+    echo "Starting DocumentDB container with init data..."
+    docker run -d \
+        --name $CONTAINER_NAME \
+        -p $DOCUMENTDB_PORT:$DOCUMENTDB_PORT \
+        -e PASSWORD=$PASSWORD \
+        -v "$INIT_DATA_DIR:/init_doc_db.d" \
+        $IMAGE_NAME \
+        --password $PASSWORD \
+        --init-data-path /init_doc_db.d
+    
+    echo "Container started with ID: $(docker ps -q -f name=$CONTAINER_NAME)"
+    echo
+    
+    # Wait for the container to be ready
+    if wait_for_documentdb; then
+        # Wait for data initialization to complete by monitoring logs
+        if wait_for_data_initialization; then
+            echo "✅ DocumentDB and data initialization are ready!"
+        else
+            echo "❌ Data initialization failed"
+            return 1
+        fi
+        
+        # Verify the data was loaded
+        verify_data
+        
+        echo
+        echo "=== Test Results Summary ==="
+        
+        # Calculate test results
+        EXPECTED_USERS=4
+        EXPECTED_PRODUCTS=4
+        EXPECTED_ORDERS=4
+        EXPECTED_ADULT_USERS=3
+        EXPECTED_IN_STOCK=3
+        EXPECTED_COMPLETED=1
+        
+        # Test results
+        USERS_PASS=$([[ "$USER_COUNT" == "$EXPECTED_USERS" ]] && echo "✅" || echo "❌")
+        PRODUCTS_PASS=$([[ "$PRODUCT_COUNT" == "$EXPECTED_PRODUCTS" ]] && echo "✅" || echo "❌")
+        ORDERS_PASS=$([[ "$ORDER_COUNT" == "$EXPECTED_ORDERS" ]] && echo "✅" || echo "❌")
+        ADULT_USERS_PASS=$([[ "$ADULT_USERS" == "$EXPECTED_ADULT_USERS" ]] && echo "✅" || echo "❌")
+        IN_STOCK_PASS=$([[ "$IN_STOCK_PRODUCTS" == "$EXPECTED_IN_STOCK" ]] && echo "✅" || echo "❌")
+        COMPLETED_PASS=$([[ "$COMPLETED_ORDERS" == "$EXPECTED_COMPLETED" ]] && echo "✅" || echo "❌")
+        
+        echo "┌─────────────────────────────┬──────────┬──────────┬────────┐"
+        echo "│ Test Case                   │ Expected │ Actual   │ Result │"
+        echo "├─────────────────────────────┼──────────┼──────────┼────────┤"
+        echo "│ Users Collection            │ $EXPECTED_USERS        │ $USER_COUNT        │ $USERS_PASS     │"
+        echo "│ Products Collection         │ $EXPECTED_PRODUCTS        │ $PRODUCT_COUNT        │ $PRODUCTS_PASS     │"
+        echo "│ Orders Collection           │ $EXPECTED_ORDERS        │ $ORDER_COUNT        │ $ORDERS_PASS     │"
+        echo "│ Adult Users (age > 30)      │ $EXPECTED_ADULT_USERS        │ $ADULT_USERS        │ $ADULT_USERS_PASS     │"
+        echo "│ Products In Stock           │ $EXPECTED_IN_STOCK        │ $IN_STOCK_PRODUCTS        │ $IN_STOCK_PASS     │"
+        echo "│ Completed Orders            │ $EXPECTED_COMPLETED        │ $COMPLETED_ORDERS        │ $COMPLETED_PASS     │"
+        echo "└─────────────────────────────┴──────────┴──────────┴────────┘"
+        echo
+        
+        # Overall result
+        if [ "$USER_COUNT" = "$EXPECTED_USERS" ] && [ "$PRODUCT_COUNT" = "$EXPECTED_PRODUCTS" ] && [ "$ORDER_COUNT" = "$EXPECTED_ORDERS" ] && [ "$ADULT_USERS" = "$EXPECTED_ADULT_USERS" ] && [ "$IN_STOCK_PRODUCTS" = "$EXPECTED_IN_STOCK" ] && [ "$COMPLETED_ORDERS" = "$EXPECTED_COMPLETED" ]; then
+            echo "🎉 OVERALL RESULT: SUCCESS! All tests passed."
+            echo "✅ Docker build completed successfully"
+            echo "✅ Container started and initialized properly"
+            echo "✅ All collections created with expected data"
+            echo "✅ All indexes created successfully"
+            echo "✅ All queries work as expected"
+            OVERALL_RESULT="SUCCESS"
+        else
+            echo "❌ OVERALL RESULT: FAILURE! Some tests failed."
+            echo "Please check the detailed results above."
+            OVERALL_RESULT="FAILURE"
+            
+            # Show container logs for debugging
+            echo
+            echo "=== Container Logs (last 50 lines) ==="
+            docker logs --tail 50 $CONTAINER_NAME
+        fi
+    else
+        echo "❌ OVERALL RESULT: FAILURE! DocumentDB failed to start properly"
+        echo
+        echo "=== Container Logs ==="
+        docker logs $CONTAINER_NAME
+        OVERALL_RESULT="FAILURE"
+    fi
+    
+    echo
+    echo "=== Post-Test Information ==="
+    echo "Stopping and cleaning up the test container..."
+    docker stop $CONTAINER_NAME
+    echo "✅ Container stopped successfully"
+    echo
+    echo "Container has been stopped. You can:"
+    echo "1. Restart container: docker start $CONTAINER_NAME"
+    echo "2. Remove container: docker rm $CONTAINER_NAME"
+    echo "3. Remove image: docker rmi $IMAGE_NAME"
+    echo "4. Run test again: ./test_init_data.sh"
+    echo
+    
+    # Exit with appropriate code
+    if [ "$OVERALL_RESULT" = "SUCCESS" ]; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+# Run the test
+main "$@"

--- a/test-init-data/test_init_invalid_data.sh
+++ b/test-init-data/test_init_invalid_data.sh
@@ -1,0 +1,421 @@
+#!/bin/bash
+
+# Test script to validate error handling for invalid initialization data
+# This script tests that DocumentDB properly handles invalid JS files and exits gracefully
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Test configuration
+CONTAINER_NAME="documentdb-invalid-init-test"
+IMAGE_NAME="documentdb-gateway-test"
+INVALID_DATA_DIR="$SCRIPT_DIR/sample-invalid-data"
+DOCKERFILE_PATH="$PROJECT_ROOT/.github/containers/Build-Ubuntu/Dockerfile_gateway"
+DOCUMENTDB_PORT="10260"
+PASSWORD="TestPassword123"
+TEST_TIMEOUT=300  # 5 minutes timeout for container to stop
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}=== DocumentDB Invalid Init-Data Test ===${NC}"
+echo "Project Root: $PROJECT_ROOT"
+echo "Script Directory: $SCRIPT_DIR"
+echo "Container: $CONTAINER_NAME"
+echo "Image: $IMAGE_NAME"
+echo "Invalid Data Directory: $INVALID_DATA_DIR"
+echo "Dockerfile: $DOCKERFILE_PATH"
+echo "DocumentDB Port: $DOCUMENTDB_PORT"
+echo "Test Timeout: ${TEST_TIMEOUT}s"
+echo
+
+# Function to print colored output
+print_status() {
+    local status=$1
+    local message=$2
+    case $status in
+        "SUCCESS")
+            echo -e "${GREEN}✅ $message${NC}"
+            ;;
+        "FAILURE")
+            echo -e "${RED}❌ $message${NC}"
+            ;;
+        "INFO")
+            echo -e "${YELLOW}ℹ️  $message${NC}"
+            ;;
+        *)
+            echo "$message"
+            ;;
+    esac
+}
+
+# Function to check if mongosh is available
+check_mongosh() {
+    print_status "INFO" "Checking Prerequisites"
+    if ! command -v mongosh >/dev/null 2>&1; then
+        print_status "FAILURE" "mongosh is not installed or not in PATH"
+        echo "Please install MongoDB Shell (mongosh) to run this test."
+        echo "Visit: https://docs.mongodb.com/mongodb-shell/install/"
+        exit 1
+    fi
+    print_status "SUCCESS" "mongosh is available: $(mongosh --version)"
+    echo
+}
+
+# Function to build the Docker image
+build_image() {
+    print_status "INFO" "Building Docker Image"
+    if [ ! -f "$DOCKERFILE_PATH" ]; then
+        print_status "FAILURE" "Dockerfile not found at $DOCKERFILE_PATH"
+        exit 1
+    fi
+    
+    echo "Building image $IMAGE_NAME from $DOCKERFILE_PATH..."
+    echo "=== Docker Build Output ==="
+    
+    # Build with verbose output
+    if docker build -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" "$PROJECT_ROOT" --no-cache 2>&1 | tee /tmp/docker_build.log; then
+        print_status "SUCCESS" "Docker image built successfully"
+        echo "=== End of Docker Build Output ==="
+    else
+        print_status "FAILURE" "Failed to build Docker image"
+        echo "=== Docker Build Error Output ==="
+        cat /tmp/docker_build.log
+        echo "=== End of Docker Build Error Output ==="
+        exit 1
+    fi
+    echo
+}
+
+# Function to cleanup previous runs
+cleanup() {
+    print_status "INFO" "Cleaning up previous containers..."
+    docker stop $CONTAINER_NAME 2>/dev/null || true
+    docker rm $CONTAINER_NAME 2>/dev/null || true
+    
+    # Clean up temporary log files
+    rm -f /tmp/docker_build.log /tmp/container_final.log /tmp/container_analysis.log
+    
+    print_status "SUCCESS" "Cleanup completed"
+}
+
+# Function to wait for container to stop and verify exit code
+wait_for_container_exit() {
+    print_status "INFO" "Waiting for container to stop (timeout: ${TEST_TIMEOUT}s)..."
+    local start_time=$(date +%s)
+    local timeout=$TEST_TIMEOUT
+    
+    while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
+        # Check if container is still running
+        if ! docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+            print_status "SUCCESS" "Container stopped automatically"
+            
+            # Get container exit code
+            local exit_code=$(docker inspect $CONTAINER_NAME --format='{{.State.ExitCode}}')
+            echo "Container exit code: $exit_code"
+            
+            # Show final container logs immediately when it stops
+            echo
+            echo "=== Final Container Logs (when container stopped) ==="
+            docker logs $CONTAINER_NAME 2>&1 | tee /tmp/container_final.log
+            echo "=== End of Final Container Logs ==="
+            echo
+            
+            # Exit code should be non-zero for failure
+            if [ "$exit_code" -ne 0 ]; then
+                print_status "SUCCESS" "Container exited with error code $exit_code (expected for invalid data)"
+                return 0
+            else
+                print_status "FAILURE" "Container exited with success code $exit_code (unexpected for invalid data)"
+                return 1
+            fi
+        fi
+        
+        echo "Container still running... ($(($(($(date +%s) - start_time))))s elapsed)"
+        
+        # Show live container logs every 10 seconds
+        if [ $(($(($(date +%s) - start_time)) % 10)) -eq 0 ]; then
+            echo "=== Live Container Logs ($(($(($(date +%s) - start_time))))s elapsed) ==="
+            docker logs --tail 20 $CONTAINER_NAME 2>&1
+            echo "=== End of Live Container Logs ==="
+        fi
+        
+        sleep 5
+    done
+    
+    print_status "FAILURE" "Container did not stop within timeout"
+    echo "=== Container Logs on Timeout ==="
+    docker logs $CONTAINER_NAME 2>&1
+    echo "=== End of Container Logs on Timeout ==="
+    return 1
+}
+
+# Function to analyze container logs for proper error messages
+analyze_logs() {
+    print_status "INFO" "Analyzing container logs for error handling..."
+    
+    # Get all container logs
+    local logs=$(docker logs $CONTAINER_NAME 2>&1)
+    
+    echo
+    echo "=== Complete Container Logs Analysis ==="
+    echo "$logs"
+    echo "=== End of Complete Container Logs Analysis ==="
+    echo
+    
+    # Save logs to file for debugging
+    echo "$logs" > /tmp/container_analysis.log
+    print_status "INFO" "Container logs saved to /tmp/container_analysis.log"
+    
+    # Check for various error indicators
+    local error_found=false
+    
+    # Check for initialization script execution
+    if echo "$logs" | grep -q "init_documentdb_data.sh\|Starting DocumentDB data initialization\|Processing initialization scripts"; then
+        print_status "SUCCESS" "Init data script was executed"
+    else
+        print_status "FAILURE" "Init data script was not executed"
+        error_found=true
+    fi
+    
+    # Check for mongosh execution
+    if echo "$logs" | grep -q "mongosh\|Executing initialization script"; then
+        print_status "SUCCESS" "mongosh was attempted to run"
+    else
+        print_status "FAILURE" "mongosh was not attempted"
+        error_found=true
+    fi
+    
+    # Check for JavaScript syntax errors
+    if echo "$logs" | grep -qi "syntax.*error\|unexpected.*token\|parse.*error"; then
+        print_status "SUCCESS" "JavaScript syntax error detected in logs"
+    else
+        print_status "INFO" "No JavaScript syntax errors found in logs"
+    fi
+    
+    # Check for MongoDB errors
+    if echo "$logs" | grep -qi "mongodb.*error\|duplicate.*key\|operation.*failed"; then
+        print_status "SUCCESS" "MongoDB operation error detected in logs"
+    else
+        print_status "INFO" "No MongoDB operation errors found in logs"
+    fi
+    
+    # Check for script failure messages
+    if echo "$logs" | grep -qi "failed.*to.*execute\|error.*executing\|initialization.*failed"; then
+        print_status "SUCCESS" "Script failure messages detected"
+    else
+        print_status "FAILURE" "No script failure messages found"
+        error_found=true
+    fi
+    
+    # Check that it didn't complete successfully
+    if echo "$logs" | grep -q "Sample data initialization completed!"; then
+        print_status "FAILURE" "Container reported successful initialization (unexpected for invalid data)"
+        error_found=true
+    else
+        print_status "SUCCESS" "Container did not report successful initialization (expected for invalid data)"
+    fi
+    
+    if [ "$error_found" = true ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Function to run a test with specific invalid data
+run_invalid_data_test() {
+    local test_name=$1
+    local invalid_file=$2
+    
+    print_status "INFO" "Running test: $test_name"
+    echo "Invalid file: $invalid_file"
+    
+    # Create a temporary directory with only the invalid file
+    local temp_dir=$(mktemp -d)
+    cp "$invalid_file" "$temp_dir/"
+    
+    echo "Test data files:"
+    ls -la "$temp_dir"/*.js
+    echo
+    
+    # Run the container with invalid data
+    print_status "INFO" "Starting DocumentDB container with invalid data..."
+    
+    echo "=== Docker Run Command ==="
+    echo "docker run -d \\"
+    echo "    --name $CONTAINER_NAME \\"
+    echo "    -p $DOCUMENTDB_PORT:$DOCUMENTDB_PORT \\"
+    echo "    -e PASSWORD=$PASSWORD \\"
+    echo "    -v \"$temp_dir:/init_doc_db.d\" \\"
+    echo "    $IMAGE_NAME \\"
+    echo "    --password $PASSWORD \\"
+    echo "    --init-data-path /init_doc_db.d"
+    echo "=== End of Docker Run Command ==="
+    echo
+    
+    if docker run -d \
+        --name $CONTAINER_NAME \
+        -p $DOCUMENTDB_PORT:$DOCUMENTDB_PORT \
+        -e PASSWORD=$PASSWORD \
+        -v "$temp_dir:/init_doc_db.d" \
+        $IMAGE_NAME \
+        --password $PASSWORD \
+        --init-data-path /init_doc_db.d; then
+        
+        print_status "SUCCESS" "Container started successfully"
+        local container_id=$(docker ps -q -f name=$CONTAINER_NAME)
+        echo "Container ID: $container_id"
+        
+        # Show immediate logs after container start
+        echo
+        echo "=== Initial Container Logs (first 5 seconds) ==="
+        sleep 5
+        docker logs $CONTAINER_NAME 2>&1
+        echo "=== End of Initial Container Logs ==="
+        echo
+        
+        # Wait for container to stop due to error
+        if wait_for_container_exit; then
+            # Analyze logs for proper error handling
+            if analyze_logs; then
+                print_status "SUCCESS" "Test '$test_name' passed - container handled invalid data correctly"
+                local test_result=0
+            else
+                print_status "FAILURE" "Test '$test_name' failed - error handling was not proper"
+                local test_result=1
+            fi
+        else
+            print_status "FAILURE" "Test '$test_name' failed - container did not stop properly"
+            echo "=== Debug: Container Status ==="
+            docker ps -a -f name=$CONTAINER_NAME
+            echo "=== Debug: Container Logs ==="
+            docker logs $CONTAINER_NAME 2>&1
+            echo "=== End of Debug Information ==="
+            local test_result=1
+        fi
+    else
+        print_status "FAILURE" "Failed to start container"
+        echo "=== Debug: Docker Run Error ==="
+        docker logs $CONTAINER_NAME 2>&1 || echo "No container logs available"
+        echo "=== End of Docker Run Error ==="
+        local test_result=1
+    fi
+    
+    # Cleanup
+    cleanup
+    rm -rf "$temp_dir"
+    
+    return $test_result
+}
+
+# Main test execution
+main() {
+    print_status "INFO" "Starting DocumentDB Invalid Init-Data Test"
+    
+    # Check prerequisites
+    check_mongosh
+    
+    # Cleanup any previous test runs
+    cleanup
+    
+    # Build the Docker image
+    build_image
+    
+    # Verify invalid data files exist
+    if [ ! -d "$INVALID_DATA_DIR" ]; then
+        print_status "FAILURE" "Invalid data directory not found at $INVALID_DATA_DIR"
+        exit 1
+    fi
+    
+    print_status "SUCCESS" "Invalid data directory found"
+    echo "Available invalid data files:"
+    ls -la "$INVALID_DATA_DIR"/*.js
+    echo
+    
+    print_status "INFO" "Docker system information:"
+    echo "Docker version: $(docker --version)"
+    echo "Docker info:"
+    docker info | head -20
+    echo
+    
+    print_status "INFO" "System information:"
+    echo "OS: $(uname -s)"
+    echo "Architecture: $(uname -m)"
+    echo "Available memory: $(free -h | grep '^Mem:' | awk '{print $2}')"
+    echo "Available disk: $(df -h . | tail -1 | awk '{print $4}')"
+    echo
+    
+    # Test results tracking
+    local total_tests=0
+    local passed_tests=0
+    local failed_tests=0
+    
+    # Run tests with different types of invalid data
+    for invalid_file in "$INVALID_DATA_DIR"/*.js; do
+        if [ -f "$invalid_file" ]; then
+            total_tests=$((total_tests + 1))
+            local test_name=$(basename "$invalid_file" .js)
+            
+            echo
+            echo "=========================================="
+            print_status "INFO" "TEST $total_tests: $test_name"
+            echo "=========================================="
+            
+            if run_invalid_data_test "$test_name" "$invalid_file"; then
+                passed_tests=$((passed_tests + 1))
+                print_status "SUCCESS" "Test $total_tests passed"
+            else
+                failed_tests=$((failed_tests + 1))
+                print_status "FAILURE" "Test $total_tests failed"
+            fi
+        fi
+    done
+    
+    # Final test summary
+    echo
+    echo "=========================================="
+    print_status "INFO" "TEST SUMMARY"
+    echo "=========================================="
+    echo "Total tests run: $total_tests"
+    echo "Tests passed: $passed_tests"
+    echo "Tests failed: $failed_tests"
+    echo
+    
+    if [ $failed_tests -eq 0 ]; then
+        print_status "SUCCESS" "ALL TESTS PASSED!"
+        echo "✅ Docker build completed successfully"
+        echo "✅ All invalid data was handled correctly"
+        echo "✅ Containers stopped automatically with proper error codes"
+        echo "✅ Error messages were properly logged"
+        echo
+        print_status "INFO" "Log files created during testing:"
+        echo "- Docker build log: /tmp/docker_build.log"
+        echo "- Container final log: /tmp/container_final.log"
+        echo "- Container analysis log: /tmp/container_analysis.log"
+        exit 0
+    else
+        print_status "FAILURE" "SOME TESTS FAILED!"
+        echo "❌ $failed_tests out of $total_tests tests failed"
+        echo "Please check the detailed results above."
+        echo
+        print_status "INFO" "Debug log files available:"
+        echo "- Docker build log: /tmp/docker_build.log"
+        echo "- Container final log: /tmp/container_final.log"
+        echo "- Container analysis log: /tmp/container_analysis.log"
+        echo
+        echo "Use 'cat /tmp/docker_build.log' to view Docker build details"
+        echo "Use 'cat /tmp/container_final.log' to view final container output"
+        echo "Use 'cat /tmp/container_analysis.log' to view container analysis"
+        exit 1
+    fi
+}
+
+# Run the test
+main "$@"

--- a/test-init-data/test_init_sample_data.sh
+++ b/test-init-data/test_init_sample_data.sh
@@ -1,0 +1,487 @@
+#!/bin/bash
+
+# Script to test the new --init-data feature of DocumentDB
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CONTAINER_NAME="documentdb-init-data-test"
+IMAGE_NAME="documentdb-init-data-test"
+DOCKERFILE_PATH="$PROJECT_ROOT/.github/containers/Build-Ubuntu/Dockerfile_gateway"
+DOCUMENTDB_PORT="10261"  # Use different port to avoid conflicts
+PASSWORD="TestPassword123"
+
+echo "=== DocumentDB --init-data Feature Test ==="
+echo "Project Root: $PROJECT_ROOT"
+echo "Script Directory: $SCRIPT_DIR"
+echo "Container: $CONTAINER_NAME"
+echo "Image: $IMAGE_NAME"
+echo "Dockerfile: $DOCKERFILE_PATH"
+echo "DocumentDB Port: $DOCUMENTDB_PORT"
+echo
+
+# Function to check if mongosh is available
+check_mongosh() {
+    echo "=== Checking Prerequisites ==="
+    if ! command -v mongosh >/dev/null 2>&1; then
+        echo "❌ Error: mongosh is not installed or not in PATH"
+        echo "Please install mongosh to run this test."
+        echo "Visit: https://docs.mongodb.com/mongodb-shell/install/"
+        exit 1
+    fi
+    echo "✅ mongosh is available: $(mongosh --version)"
+    echo
+}
+
+# Function to build the Docker image
+build_image() {
+    echo "=== Building Docker Image ==="
+    if [ ! -f "$DOCKERFILE_PATH" ]; then
+        echo "❌ Error: Dockerfile not found at $DOCKERFILE_PATH"
+        exit 1
+    fi
+    
+    # Check if sample data directory exists in the project
+    if [ ! -d "$PROJECT_ROOT/sample-data" ]; then
+        echo "❌ Error: Sample data directory not found at $PROJECT_ROOT/sample-data"
+        echo "Please ensure the sample-data directory exists with the required JavaScript files."
+        exit 1
+    fi
+    
+    echo "Sample data files found:"
+    ls -la "$PROJECT_ROOT/sample-data"/*.js
+    echo
+    
+    echo "Building image $IMAGE_NAME from $DOCKERFILE_PATH..."
+    docker build -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" "$PROJECT_ROOT"
+    echo "✅ Image built successfully"
+    echo
+}
+
+# Function to cleanup previous runs
+cleanup() {
+    echo "Cleaning up previous containers..."
+    docker stop $CONTAINER_NAME 2>/dev/null || true
+    docker rm $CONTAINER_NAME 2>/dev/null || true
+    docker stop "${CONTAINER_NAME}-env" 2>/dev/null || true
+    docker rm "${CONTAINER_NAME}-env" 2>/dev/null || true
+}
+
+# Function to wait for DocumentDB to be ready
+wait_for_documentdb() {
+    echo "Waiting for DocumentDB to be ready..."
+    local max_attempts=60  # Increased timeout for initialization
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        if mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.runCommand({ping: 1})" >/dev/null 2>&1; then
+            echo "✅ DocumentDB is ready!"
+            return 0
+        fi
+        
+        echo "Attempt $attempt/$max_attempts - waiting..."
+        sleep 3
+        attempt=$((attempt + 1))
+    done
+    
+    echo "❌ Error: DocumentDB did not become ready within timeout"
+    return 1
+}
+
+# Function to wait for sample data initialization to complete by monitoring logs
+wait_for_data_initialization() {
+    echo "Waiting for sample data initialization to complete..."
+    local max_attempts=120  # 6 minutes timeout for data initialization
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        # Check if the completion message appears in container logs
+        if docker logs $CONTAINER_NAME 2>&1 | grep -q "Sample data initialization completed!"; then
+            echo "✅ Sample data initialization completed!"
+            return 0
+        fi
+        
+        echo "Attempt $attempt/$max_attempts - waiting for data initialization completion log..."
+        sleep 3
+        attempt=$((attempt + 1))
+    done
+    
+    echo "❌ Error: Sample data initialization did not complete within timeout"
+    echo "=== Recent Container Logs ==="
+    docker logs --tail 20 $CONTAINER_NAME
+    return 1
+}
+
+# Function to verify sample data was loaded correctly
+verify_sample_data() {
+    echo "=== Verifying Sample Data Initialization ==="
+    
+    # Check if sampledb database exists and switch to it
+    echo "Checking sampledb database..."
+    DB_LIST=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.adminCommand('listDatabases')" --quiet 2>/dev/null)
+    
+    if [[ "$DB_LIST" == *"sampledb"* ]]; then
+        echo "✅ sampledb database found"
+    else
+        echo "❌ sampledb database not found"
+        echo "Available databases:"
+        echo "$DB_LIST"
+        return 1
+    fi
+    
+    # Check users collection
+    echo "Checking users collection..."
+    USER_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Users count: $USER_COUNT"
+    
+    # Check products collection
+    echo "Checking products collection..."
+    PRODUCT_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.products.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Products count: $PRODUCT_COUNT"
+    
+    # Check orders collection
+    echo "Checking orders collection..."
+    ORDER_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.orders.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Orders count: $ORDER_COUNT"
+    
+    # Check analytics collection
+    echo "Checking analytics collection..."
+    ANALYTICS_COUNT=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.analytics.countDocuments()" --quiet 2>/dev/null | tail -1)
+    echo "Analytics count: $ANALYTICS_COUNT"
+    
+    # Show sample data from each collection
+    echo
+    echo "=== Sample Data Examples ==="
+    echo "Sample user:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.findOne()" --quiet 2>/dev/null | head -10
+    
+    echo
+    echo "Sample product:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.products.findOne()" --quiet 2>/dev/null | head -10
+    
+    echo
+    echo "Sample order:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.orders.findOne()" --quiet 2>/dev/null | head -10
+    
+    echo
+    echo "Sample analytics:"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.analytics.findOne()" --quiet 2>/dev/null | head -10
+    
+    # Verify indexes were created
+    echo
+    echo "=== Checking Indexes ==="
+    echo "Users indexes:"
+    USER_INDEXES=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.getIndexes().length" --quiet 2>/dev/null | tail -1)
+    echo "Users has $USER_INDEXES indexes"
+    
+    echo "Products indexes:"
+    PRODUCT_INDEXES=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.products.getIndexes().length" --quiet 2>/dev/null | tail -1)
+    echo "Products has $PRODUCT_INDEXES indexes"
+    
+    echo "Orders indexes:"
+    ORDER_INDEXES=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.orders.getIndexes().length" --quiet 2>/dev/null | tail -1)
+    echo "Orders has $ORDER_INDEXES indexes"
+    
+    echo "Analytics indexes:"
+    ANALYTICS_INDEXES=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.analytics.getIndexes().length" --quiet 2>/dev/null | tail -1)
+    echo "Analytics has $ANALYTICS_INDEXES indexes"
+    
+    # Test some complex queries to verify data relationships
+    echo
+    echo "=== Testing Data Relationships and Queries ==="
+    
+    echo "Testing query: Users in Seattle"
+    SEATTLE_USERS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.countDocuments({city: 'Seattle'})" --quiet 2>/dev/null | tail -1)
+    echo "Users in Seattle: $SEATTLE_USERS"
+    
+    echo "Testing query: Electronics products"
+    ELECTRONICS_PRODUCTS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.products.countDocuments({category: 'Electronics'})" --quiet 2>/dev/null | tail -1)
+    echo "Electronics products: $ELECTRONICS_PRODUCTS"
+    
+    echo "Testing query: Orders with status 'delivered'"
+    DELIVERED_ORDERS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.orders.countDocuments({status: 'delivered'})" --quiet 2>/dev/null | tail -1)
+    echo "Delivered orders: $DELIVERED_ORDERS"
+    
+    echo "Testing query: Premium users"
+    PREMIUM_USERS=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.countDocuments({tags: 'premium'})" --quiet 2>/dev/null | tail -1)
+    echo "Premium users: $PREMIUM_USERS"
+    
+    # Test aggregation pipeline
+    echo "Testing aggregation: Total revenue by order status"
+    mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "
+        use('sampledb'); 
+        db.orders.aggregate([
+            { \$group: { 
+                _id: '\$status', 
+                totalRevenue: { \$sum: '\$orderSummary.total' },
+                orderCount: { \$sum: 1 }
+            }},
+            { \$sort: { totalRevenue: -1 }}
+        ]).forEach(printjson)
+    " --quiet 2>/dev/null
+    
+    # Return results for validation
+    export USER_COUNT PRODUCT_COUNT ORDER_COUNT ANALYTICS_COUNT
+    export USER_INDEXES PRODUCT_INDEXES ORDER_INDEXES ANALYTICS_INDEXES
+    export SEATTLE_USERS ELECTRONICS_PRODUCTS DELIVERED_ORDERS PREMIUM_USERS
+}
+
+# Function to test environment variable usage
+test_environment_variable() {
+    echo
+    echo "=== Testing Environment Variable (INIT_DATA) ==="
+    
+    # Cleanup first
+    cleanup
+    
+    # Test with environment variable instead of command line flag
+    echo "Starting container with INIT_DATA environment variable..."
+    docker run -d \
+        --name "${CONTAINER_NAME}-env" \
+        -p $((DOCUMENTDB_PORT + 1)):10260 \
+        -e PASSWORD=$PASSWORD \
+        -e INIT_DATA=true \
+        $IMAGE_NAME \
+        --password $PASSWORD
+    
+    ENV_CONTAINER_NAME="${CONTAINER_NAME}-env"
+    ENV_PORT=$((DOCUMENTDB_PORT + 1))
+    
+    echo "Waiting for environment variable test container to be ready..."
+    local max_attempts=60
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        if mongosh localhost:$ENV_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.runCommand({ping: 1})" >/dev/null 2>&1; then
+            echo "✅ Environment variable test container is ready!"
+            break
+        fi
+        
+        echo "Attempt $attempt/$max_attempts - waiting..."
+        sleep 3
+        attempt=$((attempt + 1))
+    done
+    
+    if [ $attempt -gt $max_attempts ]; then
+        echo "❌ Environment variable test container failed to start"
+        docker logs $ENV_CONTAINER_NAME
+        return 1
+    fi
+    
+    # Wait for data initialization to complete by monitoring logs
+    echo "Waiting for sample data initialization to complete in environment test..."
+    local data_max_attempts=120
+    local data_attempt=1
+    
+    while [ $data_attempt -le $data_max_attempts ]; do
+        if docker logs $ENV_CONTAINER_NAME 2>&1 | grep -q "Sample data initialization completed!"; then
+            echo "✅ Environment test data initialization completed!"
+            break
+        fi
+        
+        echo "Environment test attempt $data_attempt/$data_max_attempts - waiting for initialization completion log..."
+        sleep 3
+        data_attempt=$((data_attempt + 1))
+    done
+    
+    if [ $data_attempt -gt $data_max_attempts ]; then
+        echo "❌ Environment test data initialization failed"
+        docker logs --tail 20 $ENV_CONTAINER_NAME
+        return 1
+    fi
+    
+    # Quick verification
+    ENV_USER_COUNT=$(mongosh localhost:$ENV_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "use('sampledb'); db.users.countDocuments()" --quiet 2>/dev/null | tail -1)
+    
+    # Cleanup environment test container
+    docker stop $ENV_CONTAINER_NAME 2>/dev/null || true
+    docker rm $ENV_CONTAINER_NAME 2>/dev/null || true
+    
+    if [ "$ENV_USER_COUNT" = "5" ]; then
+        echo "✅ Environment variable test passed (found $ENV_USER_COUNT users)"
+        return 0
+    else
+        echo "❌ Environment variable test failed (found $ENV_USER_COUNT users, expected 5)"
+        return 1
+    fi
+}
+
+# Main test execution
+main() {
+    # Check prerequisites
+    check_mongosh
+    
+    # Cleanup any previous test runs
+    cleanup
+    
+    # Build the Docker image
+    build_image
+    
+    # Test 1: Command line flag --init-data=true
+    echo "=== Test 1: Command Line Flag (--init-data true) ==="
+    echo "Starting DocumentDB container with --init-data true..."
+    docker run -d \
+        --name $CONTAINER_NAME \
+        -p $DOCUMENTDB_PORT:10260 \
+        -e PASSWORD=$PASSWORD \
+        $IMAGE_NAME \
+        --password $PASSWORD \
+        --init-data true
+    
+    echo "Container started with ID: $(docker ps -q -f name=$CONTAINER_NAME)"
+    echo
+    
+    # Wait for the container to be ready
+    if wait_for_documentdb; then
+        # Wait for sample data initialization to complete by monitoring logs
+        if wait_for_data_initialization; then
+            echo "✅ DocumentDB and sample data are ready!"
+        else
+            echo "❌ Sample data initialization failed"
+            return 1
+        fi
+        
+        # Verify the sample data was loaded
+        if verify_sample_data; then
+            echo "✅ Sample data verification completed"
+        else
+            echo "❌ Sample data verification failed"
+            return 1
+        fi
+        
+        # Test 2: Environment variable
+        test_environment_variable
+        ENV_TEST_RESULT=$?
+        
+        echo
+        echo "=== Test Results Summary ==="
+        
+        # Expected values based on our sample data
+        EXPECTED_USERS=5
+        EXPECTED_PRODUCTS=5
+        EXPECTED_ORDERS=4
+        EXPECTED_ANALYTICS=2
+        EXPECTED_SEATTLE_USERS=1
+        EXPECTED_ELECTRONICS=2
+        EXPECTED_DELIVERED=1
+        EXPECTED_PREMIUM=3
+        
+        # Minimum expected indexes (including default _id index)
+        MIN_USER_INDEXES=5  # _id + email + username + city + tags
+        MIN_PRODUCT_INDEXES=6  # _id + category + brand + price + tags + sku
+        MIN_ORDER_INDEXES=6  # _id + userId + orderNumber + status + orderDate + customerInfo.email
+        MIN_ANALYTICS_INDEXES=4  # _id + period + type + date
+        
+        # Test results
+        USERS_PASS=$([[ "$USER_COUNT" == "$EXPECTED_USERS" ]] && echo "✅" || echo "❌")
+        PRODUCTS_PASS=$([[ "$PRODUCT_COUNT" == "$EXPECTED_PRODUCTS" ]] && echo "✅" || echo "❌")
+        ORDERS_PASS=$([[ "$ORDER_COUNT" == "$EXPECTED_ORDERS" ]] && echo "✅" || echo "❌")
+        ANALYTICS_PASS=$([[ "$ANALYTICS_COUNT" == "$EXPECTED_ANALYTICS" ]] && echo "✅" || echo "❌")
+        SEATTLE_PASS=$([[ "$SEATTLE_USERS" == "$EXPECTED_SEATTLE_USERS" ]] && echo "✅" || echo "❌")
+        ELECTRONICS_PASS=$([[ "$ELECTRONICS_PRODUCTS" == "$EXPECTED_ELECTRONICS" ]] && echo "✅" || echo "❌")
+        DELIVERED_PASS=$([[ "$DELIVERED_ORDERS" == "$EXPECTED_DELIVERED" ]] && echo "✅" || echo "❌")
+        PREMIUM_PASS=$([[ "$PREMIUM_USERS" == "$EXPECTED_PREMIUM" ]] && echo "✅" || echo "❌")
+        USER_IDX_PASS=$([[ "$USER_INDEXES" -ge "$MIN_USER_INDEXES" ]] && echo "✅" || echo "❌")
+        PRODUCT_IDX_PASS=$([[ "$PRODUCT_INDEXES" -ge "$MIN_PRODUCT_INDEXES" ]] && echo "✅" || echo "❌")
+        ORDER_IDX_PASS=$([[ "$ORDER_INDEXES" -ge "$MIN_ORDER_INDEXES" ]] && echo "✅" || echo "❌")
+        ANALYTICS_IDX_PASS=$([[ "$ANALYTICS_INDEXES" -ge "$MIN_ANALYTICS_INDEXES" ]] && echo "✅" || echo "❌")
+        ENV_PASS=$([[ "$ENV_TEST_RESULT" == "0" ]] && echo "✅" || echo "❌")
+        
+        echo "┌─────────────────────────────────┬──────────┬──────────┬────────┐"
+        echo "│ Test Case                       │ Expected │ Actual   │ Result │"
+        echo "├─────────────────────────────────┼──────────┼──────────┼────────┤"
+        echo "│ Users Collection                │ $EXPECTED_USERS        │ $USER_COUNT        │ $USERS_PASS     │"
+        echo "│ Products Collection             │ $EXPECTED_PRODUCTS        │ $PRODUCT_COUNT        │ $PRODUCTS_PASS     │"
+        echo "│ Orders Collection               │ $EXPECTED_ORDERS        │ $ORDER_COUNT        │ $ORDERS_PASS     │"
+        echo "│ Analytics Collection            │ $EXPECTED_ANALYTICS        │ $ANALYTICS_COUNT        │ $ANALYTICS_PASS     │"
+        echo "│ Seattle Users Query             │ $EXPECTED_SEATTLE_USERS        │ $SEATTLE_USERS        │ $SEATTLE_PASS     │"
+        echo "│ Electronics Products Query      │ $EXPECTED_ELECTRONICS        │ $ELECTRONICS_PRODUCTS        │ $ELECTRONICS_PASS     │"
+        echo "│ Delivered Orders Query          │ $EXPECTED_DELIVERED        │ $DELIVERED_ORDERS        │ $DELIVERED_PASS     │"
+        echo "│ Premium Users Query             │ $EXPECTED_PREMIUM        │ $PREMIUM_USERS        │ $PREMIUM_PASS     │"
+        echo "│ Users Indexes (min $MIN_USER_INDEXES)           │ >=$MIN_USER_INDEXES       │ $USER_INDEXES        │ $USER_IDX_PASS     │"
+        echo "│ Products Indexes (min $MIN_PRODUCT_INDEXES)        │ >=$MIN_PRODUCT_INDEXES       │ $PRODUCT_INDEXES        │ $PRODUCT_IDX_PASS     │"
+        echo "│ Orders Indexes (min $MIN_ORDER_INDEXES)          │ >=$MIN_ORDER_INDEXES       │ $ORDER_INDEXES        │ $ORDER_IDX_PASS     │"
+        echo "│ Analytics Indexes (min $MIN_ANALYTICS_INDEXES)       │ >=$MIN_ANALYTICS_INDEXES       │ $ANALYTICS_INDEXES        │ $ANALYTICS_IDX_PASS     │"
+        echo "│ Environment Variable Test       │ PASS     │ $([ "$ENV_TEST_RESULT" = "0" ] && echo "PASS" || echo "FAIL")     │ $ENV_PASS     │"
+        echo "└─────────────────────────────────┴──────────┴──────────┴────────┘"
+        echo
+        
+        # Overall result
+        ALL_TESTS_PASSED=true
+        
+        # Check all conditions
+        [ "$USER_COUNT" != "$EXPECTED_USERS" ] && ALL_TESTS_PASSED=false
+        [ "$PRODUCT_COUNT" != "$EXPECTED_PRODUCTS" ] && ALL_TESTS_PASSED=false
+        [ "$ORDER_COUNT" != "$EXPECTED_ORDERS" ] && ALL_TESTS_PASSED=false
+        [ "$ANALYTICS_COUNT" != "$EXPECTED_ANALYTICS" ] && ALL_TESTS_PASSED=false
+        [ "$SEATTLE_USERS" != "$EXPECTED_SEATTLE_USERS" ] && ALL_TESTS_PASSED=false
+        [ "$ELECTRONICS_PRODUCTS" != "$EXPECTED_ELECTRONICS" ] && ALL_TESTS_PASSED=false
+        [ "$DELIVERED_ORDERS" != "$EXPECTED_DELIVERED" ] && ALL_TESTS_PASSED=false
+        [ "$PREMIUM_USERS" != "$EXPECTED_PREMIUM" ] && ALL_TESTS_PASSED=false
+        [ "$USER_INDEXES" -lt "$MIN_USER_INDEXES" ] && ALL_TESTS_PASSED=false
+        [ "$PRODUCT_INDEXES" -lt "$MIN_PRODUCT_INDEXES" ] && ALL_TESTS_PASSED=false
+        [ "$ORDER_INDEXES" -lt "$MIN_ORDER_INDEXES" ] && ALL_TESTS_PASSED=false
+        [ "$ANALYTICS_INDEXES" -lt "$MIN_ANALYTICS_INDEXES" ] && ALL_TESTS_PASSED=false
+        [ "$ENV_TEST_RESULT" != "0" ] && ALL_TESTS_PASSED=false
+        
+        if [ "$ALL_TESTS_PASSED" = true ]; then
+            echo "🎉 OVERALL RESULT: SUCCESS! All tests passed."
+            echo "✅ Docker build completed successfully"
+            echo "✅ Container started and initialized properly"
+            echo "✅ All sample collections created with expected data"
+            echo "✅ All indexes created successfully"
+            echo "✅ All queries work as expected"
+            echo "✅ Data relationships are correct"
+            echo "✅ Environment variable works correctly"
+            echo "✅ --init-data feature is working perfectly!"
+            OVERALL_RESULT="SUCCESS"
+        else
+            echo "❌ OVERALL RESULT: FAILURE! Some tests failed."
+            echo "Please check the detailed results above."
+            OVERALL_RESULT="FAILURE"
+            
+            # Show container logs for debugging
+            echo
+            echo "=== Container Logs (last 100 lines) ==="
+            docker logs --tail 100 $CONTAINER_NAME
+        fi
+    else
+        echo "❌ OVERALL RESULT: FAILURE! DocumentDB failed to start properly"
+        echo
+        echo "=== Container Logs ==="
+        docker logs $CONTAINER_NAME
+        OVERALL_RESULT="FAILURE"
+    fi
+    
+    echo
+    echo "=== Post-Test Information ==="
+    echo "Stopping and cleaning up the test containers..."
+    docker stop $CONTAINER_NAME 2>/dev/null || true
+    docker rm $CONTAINER_NAME 2>/dev/null || true
+    docker stop "${CONTAINER_NAME}-env" 2>/dev/null || true
+    docker rm "${CONTAINER_NAME}-env" 2>/dev/null || true
+    echo "✅ Containers stopped and removed successfully"
+    echo
+    echo "To manually explore the sample data:"
+    echo "1. Start container: docker run -d --name documentdb-manual -p 10260:10260 -e PASSWORD=mypass $IMAGE_NAME --password mypass --init-data true"
+    echo "2. Connect: mongosh localhost:10260 -u default_user -p mypass --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates"
+    echo "3. Use database: use('sampledb')"
+    echo "4. Explore: db.users.find(), db.products.find(), db.orders.find(), db.analytics.find()"
+    echo
+    echo "Cleanup commands:"
+    echo "1. Remove container: docker rm $CONTAINER_NAME"
+    echo "2. Remove image: docker rmi $IMAGE_NAME"
+    echo
+    
+    # Exit with appropriate code
+    if [ "$OVERALL_RESULT" = "SUCCESS" ]; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+# Run the test
+main "$@"


### PR DESCRIPTION
This Pull Request add a feature to allow user initialize the database emulator with build in sample data.
The emulator start up script will inject the sample data in the repo and create a db called "sampledb".
The user can use flag argument --init-data to enable this feature. Also can use --init-data-path to initialize the database with customer provided data.