### PR TITLE
Enable direct executor path for single-node deployments

### DIFF
--- a/pg_documentdb/src/api_hooks.c
+++ b/pg_documentdb/src/api_hooks.c
@@ -400,7 +400,8 @@ TryGetShardNameForUnshardedCollection(Oid relationOid, uint64 collectionId, cons
 																tableName);
 	}
 
-	return NULL;
+	/* Single node: return tableName to enable direct Executor path */
+	return tableName;
 }
 
 

--- a/pg_documentdb/src/metadata/collection.c
+++ b/pg_documentdb/src/metadata/collection.c
@@ -576,6 +576,8 @@ TrySetCollectionShard(MongoCollection *collection)
 
 	int savedGUCLevel = NewGUCNestLevel();
 	SetGUCLocally("client_min_messages", "WARNING");
+
+	/* Get shard table name (distributed) or original tableName (single node) */
 	const char *shardName = TryGetShardNameForUnshardedCollection(
 		collection->relationId, collection->collectionId, collection->tableName);
 	RollbackGUCChange(savedGUCLevel);


### PR DESCRIPTION
Hi, I'm Andy from Kakao (Korea). This is a small but useful optimization for single-node deployments.

**Summary**
Enable direct Executor path for single-node deployments.

**Problem**
`TryGetShardNameForUnshardedCollection()` returns `NULL` in single-node environments, forcing all INSERT/UPDATE/DELETE operations through the slower SPI path.

Single-node is a common deployment scenario, but this code path was not optimized for it.

**Solution**
Return `tableName` instead of `NULL` for single-node setup. This enables the direct Executor path previously only available for distributed environments.

**Why This Is Safe**
1. Single-node has no shards - the original table name is the only valid target
2. No impact on distributed setup - existing hook mechanism unchanged

**Performance**
40-50% faster write operations

Simple test (100K inserts):
```
psql : 
\timing on
DO $$
BEGIN
  FOR i IN 1..100000 LOOP
    PERFORM documentdb_api.insert_one('testdb', 'bench', format('{"x": %s}', i)::jsonb::text::documentdb_core.bson);
  END LOOP;
END $$;
```

- All existing tests pass (`make check-no-distributed`)