### PR TITLE
[BUG FIX]: update command failing with "The BSON field 'insert.update' is not recognized as a valid field"

### DIFF
--- a/pg_documentdb_gw/src/postgres/documentdb_data_client.rs
+++ b/pg_documentdb_gw/src/postgres/documentdb_data_client.rs
@@ -659,7 +659,10 @@ impl PgDataClient for DocumentDBDataClient {
     ) -> Result<Vec<Row>> {
         let (request, request_info, request_tracker) = request_context.get_components();
 
-        let mut query_str: &str = connection_context.service_context.query_catalog().insert();
+        let mut query_str: &str = connection_context
+            .service_context
+            .query_catalog()
+            .process_update();
 
         if enable_write_procedures_with_batch_commit
             && connection_context.transaction.is_none()


### PR DESCRIPTION
## Problem
updateOne operations were failing with error: "The BSON field 'insert.update' is not recognized as a valid field"

## Root Cause
Line 662 in documentdb_data_client.rs was incorrectly calling `insert()` instead of `process_update()` for update operations.

## Reproduce the error
[direct: mongos] test> db.coll.updateOne({a:1}, {$set: {a:2}})
MongoServerError: The BSON field 'insert.update' is not recognized as a valid field.

## Solution
Changed the default query string to use `process_update()`

## Testing
Verified that `db.coll.updateOne({a:1}, {$set: {a:2}})` now executes successfully.
