### PR TITLE
fix(gateway): use TCP localhost:5432 for CNPG package-based images

### DIFF
--- a/scripts/build_and_start_gateway.sh
+++ b/scripts/build_and_start_gateway.sh
@@ -121,7 +121,7 @@ if [ "$createUser" = "true" ]; then
         exit 1
     fi
 
-    SetupCustomAdminUser "$userName" "$userPassword" "$port" "$owner"
+    SetupCustomAdminUser "$userName" "$userPassword" "$port" "$owner" "$hostname"
 else
     echo "Skipping user creation."
 fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -115,10 +115,11 @@ function SetupCustomAdminUser()
   local pass=$2
   local port=$3
   local owner=$4
+  local host=${5:-localhost}
 
-  echo "Setting up custom user $user with owner $owner.";
-  if ! psql -p "$port" -U "$owner" -d postgres -c "SELECT 1 FROM pg_roles WHERE rolname = '$user';" | grep -q 1; then
-    psql -p $port -U $owner -d postgres -c "SELECT documentdb_api.create_user('{\"createUser\":\"$user\", \"pwd\":\"$pass\", \"roles\":[{\"role\":\"readWriteAnyDatabase\",\"db\":\"admin\"}, {\"role\":\"clusterAdmin\",\"db\":\"admin\"}]}');";
+  echo "Setting up custom user $user with owner $owner on host $host.";
+  if ! psql -h "$host" -p "$port" -U "$owner" -d postgres -c "SELECT 1 FROM pg_roles WHERE rolname = '$user';" | grep -q 1; then
+    psql -h "$host" -p "$port" -U "$owner" -d postgres -c "SELECT documentdb_api.create_user('{\"createUser\":\"$user\", \"pwd\":\"$pass\", \"roles\":[{\"role\":\"readWriteAnyDatabase\",\"db\":\"admin\"}, {\"role\":\"clusterAdmin\",\"db\":\"admin\"}]}');";
   else
     echo "Role $user already exists."
   fi


### PR DESCRIPTION
Package-based gateway images (for example pg16-0.109.0/pg16-0.110.0) default psql to the Unix socket /var/run/postgresql/.s.PGSQL.5432, which is not
  present in CNPG sidecar deployments and causes gateway crash loops. This PR updates gateway startup/probe DB connections to explicitly use TCP (localhost:5432) in CNPG
  mode, aligning behavior with the working source-built documentdb-local:16 image.