### PR TITLE
Add missing PostgreSQL build dependencies to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libtool \
     libicu-dev \
     libssl-dev \
+    liblz4-dev \
+    libzstd-dev \
+    libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Add pgdg repo


### PR DESCRIPTION
Added liblz4-dev, libzstd-dev, and libxml2-dev packages to fix PostgreSQL compilation errors during Docker image build.