### PR TITLE
Copr packaging

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -17,8 +17,8 @@ SRCDIR   := $(TOPDIR)/SOURCES
 srpm:
 	mkdir -p $(outdir) $(SRCDIR) $(TOPDIR)/SPECS $(TOPDIR)/SRPMS
 
-	# ---- Install cargo/rust (not available until mock installs BuildRequires) ----
-	dnf install -y cargo rust
+	# ---- Install cargo/rust/git (not available until mock installs BuildRequires) ----
+	dnf install -y cargo rust git
 
 	# ---- Source1: mongo-c-driver ----
 	curl -L -o $(SRCDIR)/mongo-c-driver-$(LIBBSON_VERSION).tar.gz \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,55 @@
+# .copr/Makefile — called by Copr SCM integration to produce an SRPM.
+# Usage: make -f .copr/Makefile srpm outdir=<results-dir>
+
+SPEC     := packaging/rpm/spec/documentdb-copr.spec
+VERSION  := $(shell grep -m1 '^Version:' $(SPEC) | awk '{print $$2}')
+PG_VER   := $(shell grep '%global pg_version' $(SPEC) | awk '{print $$3}')
+PKG_NAME := postgresql$(PG_VER)-documentdb
+
+LIBBSON_VERSION     := 1.28.0
+INTELMATHLIB_TAG    := applied/2.0u3-1
+INTELMATHLIB_TARVER := 2.0u3-1
+
+TOPDIR   := $(shell pwd)/rpmbuild
+SRCDIR   := $(TOPDIR)/SOURCES
+
+.PHONY: srpm
+srpm:
+	mkdir -p $(outdir) $(SRCDIR) $(TOPDIR)/SPECS $(TOPDIR)/SRPMS
+
+	# ---- Install cargo/rust (not available until mock installs BuildRequires) ----
+	dnf install -y cargo rust
+
+	# ---- Source1: mongo-c-driver ----
+	curl -L -o $(SRCDIR)/mongo-c-driver-$(LIBBSON_VERSION).tar.gz \
+	    https://github.com/mongodb/mongo-c-driver/releases/download/$(LIBBSON_VERSION)/mongo-c-driver-$(LIBBSON_VERSION).tar.gz
+
+	# ---- Source2: Intel Decimal Math Library ----
+	git clone --depth 1 -b $(INTELMATHLIB_TAG) \
+	    https://git.launchpad.net/ubuntu/+source/intelrdfpmath \
+	    intelrdfpmath-$(INTELMATHLIB_TARVER)
+	tar czf $(SRCDIR)/intelrdfpmath-$(INTELMATHLIB_TARVER).tar.gz \
+	    intelrdfpmath-$(INTELMATHLIB_TARVER)
+	rm -rf intelrdfpmath-$(INTELMATHLIB_TARVER)
+
+	# ---- Source3: Cargo vendor tarball for the gateway ----
+	cd pg_documentdb_gw && cargo vendor && \
+	    tar czf $(SRCDIR)/documentdb-gateway-vendor.tar.gz vendor/ && \
+	    rm -rf vendor
+
+	# ---- Source0: main source tarball ----
+	tar czf $(SRCDIR)/$(PKG_NAME)-$(VERSION).tar.gz \
+	    --transform 's,^\.,$(PKG_NAME)-$(VERSION),' \
+	    --exclude=.git \
+	    --exclude=rpmbuild \
+	    --exclude=intelrdfpmath-$(INTELMATHLIB_TARVER) \
+	    .
+
+	# ---- Build the SRPM ----
+	rpmbuild \
+	    --define "_topdir $(TOPDIR)" \
+	    --define "_sourcedir $(SRCDIR)" \
+	    -bs $(SPEC)
+
+	# ---- Copy SRPM to Copr output directory ----
+	cp $(TOPDIR)/SRPMS/*.src.rpm $(outdir)/

--- a/Dockerfile.fedora-test
+++ b/Dockerfile.fedora-test
@@ -1,0 +1,42 @@
+FROM fedora:42
+
+ARG POSTGRES_VERSION=18
+
+# 1. Add PGDG repos (main + common for geospatial deps like gdal, geos, proj)
+#    Note: only x86_64 available for Fedora; use --platform linux/amd64 on ARM hosts
+RUN echo -e "[pgdg${POSTGRES_VERSION}]\nname=PostgreSQL ${POSTGRES_VERSION} for Fedora \$releasever - \$basearch\nbaseurl=https://download.postgresql.org/pub/repos/yum/${POSTGRES_VERSION}/fedora/fedora-\$releasever-\$basearch/\ngpgcheck=0\nenabled=1\n\n[pgdg-common]\nname=PostgreSQL common RPMs for Fedora \$releasever - \$basearch\nbaseurl=https://download.postgresql.org/pub/repos/yum/common/fedora/fedora-\$releasever-\$basearch/\ngpgcheck=0\nenabled=1" \
+    > /etc/yum.repos.d/pgdg.repo
+
+# 2. Install PostgreSQL from PGDG
+RUN dnf install -y \
+    postgresql${POSTGRES_VERSION} \
+    postgresql${POSTGRES_VERSION}-server \
+    postgresql${POSTGRES_VERSION}-libs
+
+# 3. Install optional PG extensions (skip unavailable ones)
+RUN dnf install -y --skip-broken \
+    pgvector_${POSTGRES_VERSION} \
+    pg_cron_${POSTGRES_VERSION} || true
+
+# 4. Enable the Copr repo and install DocumentDB
+RUN dnf install -y 'dnf-command(copr)' && \
+    dnf copr enable -y xgerman/DocumentDB && \
+    dnf install -y \
+    postgresql${POSTGRES_VERSION}-documentdb \
+    documentdb-gateway \
+    documentdb-server
+
+# 5. Locale (needed for regression tests)
+RUN dnf install -y glibc-langpack-en && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 || true
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# 6. Smoke test
+ENV PATH=/usr/pgsql-${POSTGRES_VERSION}/bin:$PATH
+USER postgres
+RUN initdb -D /var/lib/pgsql/${POSTGRES_VERSION}/data && \
+    pg_ctl -D /var/lib/pgsql/${POSTGRES_VERSION}/data start && \
+    psql -c "CREATE EXTENSION documentdb_core CASCADE;" && \
+    psql -c "CREATE EXTENSION documentdb CASCADE;" && \
+    pg_ctl -D /var/lib/pgsql/${POSTGRES_VERSION}/data stop

--- a/docs/v1/introduction.md
+++ b/docs/v1/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-`DocumentDB` is the engine powering vCore-based Azure Cosmos DB for MongoDB. It offers a native implementation of document-oriented NoSQL database, enabling seamless CRUD operations on BSON data types within a PostgreSQL framework. Beyond basic operations, DocumentDB empowers you to execute complex workloads, including full-text searches, geospatial queries, and vector embeddings on your dataset, delivering robust functionality and flexibility for diverse data management needs.
+`DocumentDB` is the engine powering Azure DocumentDB. It offers a native implementation of document-oriented NoSQL database, enabling seamless CRUD operations on BSON data types within a PostgreSQL framework. Beyond basic operations, DocumentDB empowers you to execute complex workloads, including full-text searches, geospatial queries, and vector embeddings on your dataset, delivering robust functionality and flexibility for diverse data management needs.
 
 [PostgreSQL](https://www.postgresql.org/about/) is a powerful, open source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads.
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -109,6 +109,7 @@ Configure the package source in the Copr project:
 | Source type | SCM |
 | SCM type   | git |
 | Clone URL  | `https://github.com/documentdb/documentdb` |
+| SRPM build method | `make_srpm` |
 | Spec file  | `packaging/rpm/spec/documentdb-copr.spec` |
 
 The `.copr/Makefile` in the repository root handles SRPM generation automatically — Copr invokes `make srpm` and the Makefile takes care of the rest.
@@ -145,3 +146,14 @@ dnf install documentdb-gateway
 |------|---------|
 | `packaging/rpm/spec/documentdb.spec` | Docker-based RPM build (existing) |
 | `packaging/rpm/spec/documentdb-copr.spec` | Copr-compatible spec for Fedora builds |
+
+### Testing Copr Builds Locally
+
+Before pushing to Copr, you can test the SRPM build locally in a Fedora container:
+
+```sh
+./packaging/test_copr_srpm.sh
+```
+
+This requires Docker and replicates the Copr mock chroot environment. The resulting SRPM
+is placed in the `packaging/` directory by default (override with `--output-dir`).

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -92,16 +92,22 @@ The resulting gateway packages will be placed in the output directory (default: 
 1. Go to <https://copr.fedorainfracloud.org> and create a new project (or use an existing one).
 2. Under **Settings → Chroots**, enable:
    - `fedora-42-x86_64`
+   - `fedora-42-aarch64`
    - `epel-9-x86_64`
    - `epel-9-aarch64`
-   > **Note:** PGDG does not publish aarch64 packages for Fedora, so Fedora is x86_64 only.
-   > For aarch64 support, use the EPEL-9 chroots (RHEL 9 / Rocky 9 / Alma 9).
+   > **Note:** PGDG does not publish aarch64 packages for Fedora, so the Fedora aarch64
+   > COPR build uses the RHEL 9 PGDG repo for PostgreSQL dependencies at build time.
+   > For EPEL-9, PGDG provides both x86_64 and aarch64 natively.
 3. Under **Settings → External Repositories**, add the PGDG repos:
 
    **For Fedora chroots:**
    ```
    https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-42-x86_64/
+   https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-9-$basearch/
    ```
+   > **Note:** The RHEL 9 URL is needed for the Fedora aarch64 chroot since PGDG
+   > does not publish Fedora aarch64 packages. The Fedora x86_64 chroot uses
+   > the Fedora-specific URL.
 
    **For EPEL-9 chroots:**
    ```
@@ -155,7 +161,18 @@ dnf install documentdb-gateway
 | File | Purpose |
 |------|---------|
 | `packaging/rpm/spec/documentdb.spec` | Docker-based RPM build (existing) |
-| `packaging/rpm/spec/documentdb-copr.spec` | Copr-compatible spec for Fedora builds |
+| `packaging/rpm/spec/documentdb-copr.spec` | Copr-compatible spec for Fedora and EPEL builds |
+
+### Vendored Build Dependencies
+
+The Copr spec vendors the following libraries from source to avoid distro-specific
+packaging gaps:
+
+| Library | Reason |
+|---------|--------|
+| libbson (mongo-c-driver) | Statically linked; not available as a system package in PGDG |
+| Intel Decimal Math Library | Not packaged in any distro |
+| pcre2 (static) | `pcre2-static` is not available on EL9 without enabling the CRB repo |
 
 ### Testing Copr Builds Locally
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -85,22 +85,30 @@ The resulting gateway packages will be placed in the output directory (default: 
 
 ## Copr RPM Distribution
 
-[Copr](https://copr.fedorainfracloud.org) provides hosted RPM builds for Fedora. This section describes how to set up a Copr project that builds DocumentDB directly from the Git repository.
+[Copr](https://copr.fedorainfracloud.org) provides hosted RPM builds for Fedora and EPEL. This section describes how to set up a Copr project that builds DocumentDB directly from the Git repository.
 
 ### Copr Project Setup
 
 1. Go to <https://copr.fedorainfracloud.org> and create a new project (or use an existing one).
 2. Under **Settings → Chroots**, enable:
    - `fedora-42-x86_64`
-   > **Note:** PGDG does not currently publish aarch64 packages for Fedora, so only x86_64 is supported.
-3. Under **Settings → External Repositories**, add the PGDG Fedora repo so build dependencies like `postgresql18-devel`, `pgvector_18`, `pg_cron_18`, `postgis36_18`, and `rum_18` are available:
+   - `epel-9-x86_64`
+   - `epel-9-aarch64`
+   > **Note:** PGDG does not publish aarch64 packages for Fedora, so Fedora is x86_64 only.
+   > For aarch64 support, use the EPEL-9 chroots (RHEL 9 / Rocky 9 / Alma 9).
+3. Under **Settings → External Repositories**, add the PGDG repos:
+
+   **For Fedora chroots:**
    ```
-   https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-42-$basearch/
+   https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-42-x86_64/
    ```
-   > **Note:** PGDG does not publish repos for every Fedora version. Use the latest
-   > supported version (e.g. `42`) rather than `$releasever`. Use `$basearch` to support
-   > both x86_64 and aarch64. Avoid `fedora-rawhide` chroots unless PGDG has published
-   > packages for that version.
+
+   **For EPEL-9 chroots:**
+   ```
+   https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-9-$basearch/
+   ```
+   > **Note:** The EPEL-9 repo URL uses `$basearch` which expands to `x86_64` or `aarch64`
+   > depending on the build chroot.
 
 ### SCM Integration
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -82,3 +82,66 @@ Supported DEB/Ubuntu distributions:
 Supported PG versions: 15, 16, 17, 18
 
 The resulting gateway packages will be placed in the output directory (default: `packaging`). You can change the output location with the `--output-dir` option.
+
+## Copr RPM Distribution
+
+[Copr](https://copr.fedorainfracloud.org) provides hosted RPM builds for Fedora. This section describes how to set up a Copr project that builds DocumentDB directly from the Git repository.
+
+### Copr Project Setup
+
+1. Go to <https://copr.fedorainfracloud.org> and create a new project (or use an existing one).
+2. Under **Settings → Chroots**, enable:
+   - `fedora-rawhide-x86_64`
+   - `fedora-41-x86_64`
+   - `fedora-42-x86_64`
+3. Under **Settings → External Repositories**, add the PGDG Fedora repo so build dependencies like `postgresql18-devel`, `pgvector_18`, `pg_cron_18`, `postgis36_18`, and `rum_18` are available:
+   ```
+   https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-$releasever-x86_64/
+   ```
+   > **Note:** The `$releasever` variable is expanded by Copr at build time to match the target chroot.
+
+### SCM Integration
+
+Configure the package source in the Copr project:
+
+| Setting    | Value |
+|------------|-------|
+| Source type | SCM |
+| SCM type   | git |
+| Clone URL  | `https://github.com/documentdb/documentdb` |
+| Spec file  | `packaging/rpm/spec/documentdb-copr.spec` |
+
+The `.copr/Makefile` in the repository root handles SRPM generation automatically — Copr invokes `make srpm` and the Makefile takes care of the rest.
+
+Optionally, configure a webhook in **Settings → Webhooks** to trigger automatic rebuilds on push.
+
+### Packages Produced
+
+| Package | Description |
+|---------|-------------|
+| `postgresql18-documentdb` | PostgreSQL 18 extensions (`documentdb_core`, `documentdb`, `documentdb_extended_rum`) |
+| `documentdb-gateway` | MongoDB wire protocol gateway binary |
+| `documentdb-server` | Meta-package that installs everything above |
+
+### User Installation
+
+Enable the Copr repo and install:
+
+```sh
+dnf copr enable <owner>/<project>
+dnf install documentdb-server
+```
+
+Or install individual packages:
+
+```sh
+dnf install postgresql18-documentdb
+dnf install documentdb-gateway
+```
+
+### Spec Files
+
+| File | Purpose |
+|------|---------|
+| `packaging/rpm/spec/documentdb.spec` | Docker-based RPM build (existing) |
+| `packaging/rpm/spec/documentdb-copr.spec` | Copr-compatible spec for Fedora builds |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -91,14 +91,16 @@ The resulting gateway packages will be placed in the output directory (default: 
 
 1. Go to <https://copr.fedorainfracloud.org> and create a new project (or use an existing one).
 2. Under **Settings → Chroots**, enable:
-   - `fedora-rawhide-x86_64`
-   - `fedora-41-x86_64`
    - `fedora-42-x86_64`
+   > **Note:** PGDG does not currently publish aarch64 packages for Fedora, so only x86_64 is supported.
 3. Under **Settings → External Repositories**, add the PGDG Fedora repo so build dependencies like `postgresql18-devel`, `pgvector_18`, `pg_cron_18`, `postgis36_18`, and `rum_18` are available:
    ```
-   https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-$releasever-x86_64/
+   https://download.postgresql.org/pub/repos/yum/18/fedora/fedora-42-$basearch/
    ```
-   > **Note:** The `$releasever` variable is expanded by Copr at build time to match the target chroot.
+   > **Note:** PGDG does not publish repos for every Fedora version. Use the latest
+   > supported version (e.g. `42`) rather than `$releasever`. Use `$basearch` to support
+   > both x86_64 and aarch64. Avoid `fedora-rawhide` chroots unless PGDG has published
+   > packages for that version.
 
 ### SCM Integration
 

--- a/packaging/deb/common/control
+++ b/packaging/deb/common/control
@@ -7,4 +7,4 @@ Maintainer: Shuai Tian <shuaitian@microsoft.com>
 Package: postgresql-POSTGRES_VERSION-documentdb
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-POSTGRES_VERSION, postgresql-POSTGRES_VERSION-cron, postgresql-POSTGRES_VERSION-pgvector, postgresql-POSTGRES_VERSION-postgis-3, postgresql-POSTGRES_VERSION-rum
-Description: DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for MongoDB. It offers a native implementation of document-oriented NoSQL database, enabling seamless CRUD operations on BSON data types within a PostgreSQL framework.
+Description: DocumentDB is the open-source engine powering Azure DocumentDB. It offers a native implementation of document-oriented NoSQL database, enabling seamless CRUD operations on BSON data types within a PostgreSQL framework.

--- a/packaging/rpm/spec/documentdb-copr.spec
+++ b/packaging/rpm/spec/documentdb-copr.spec
@@ -52,8 +52,8 @@ Provides:       bundled(libbson) = %{libbson_version}
 Provides:       bundled(intelmathlib) = %{intelmathlib_version}
 
 %description
-DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for
-MongoDB. It offers a native implementation of document-oriented NoSQL database,
+DocumentDB is the open-source engine powering Azure DocumentDB.
+It offers a native implementation of document-oriented NoSQL database,
 enabling seamless CRUD operations on BSON data types within a PostgreSQL
 framework.
 
@@ -207,7 +207,7 @@ rm -rf %{buildroot}/usr/src/documentdb/pg_documentdb_gw/vendor
 
 # ===========================================================================
 %files
-%license LICENSE
+%license LICENSE NOTICE licenses/
 %defattr(-,root,root,-)
 /usr/pgsql-%{pg_version}/lib/*.so
 /usr/pgsql-%{pg_version}/share/extension/*.control
@@ -220,11 +220,11 @@ rm -rf %{buildroot}/usr/src/documentdb/pg_documentdb_gw/vendor
 %{_libdir}/pkgconfig/libbson-static-1.0.pc
 
 %files -n documentdb-gateway
-%license LICENSE
+%license LICENSE NOTICE
 %{_bindir}/documentdb_gateway
 
 %files -n documentdb-server
-%license LICENSE
+%license LICENSE NOTICE
 
 # ===========================================================================
 %changelog

--- a/packaging/rpm/spec/documentdb-copr.spec
+++ b/packaging/rpm/spec/documentdb-copr.spec
@@ -1,6 +1,7 @@
 %global pg_version 18
 %global libbson_version 1.28.0
 %global intelmathlib_version 2.0u3-1
+%global pcre2_version 10.44
 
 %define debug_package %{nil}
 
@@ -17,6 +18,8 @@ Source1:        https://github.com/mongodb/mongo-c-driver/releases/download/%{li
 Source2:        intelrdfpmath-%{intelmathlib_version}.tar.gz
 # Generate: cd pg_documentdb_gw && cargo vendor && tar czf ../documentdb-gateway-vendor.tar.gz vendor/
 Source3:        documentdb-gateway-vendor.tar.gz
+# Vendored pcre2 source (EL9 lacks pcre2-static without CRB)
+Source4:        https://github.com/PCRE2Project/pcre2/releases/download/pcre2-%{pcre2_version}/pcre2-%{pcre2_version}.tar.gz
 
 ExclusiveArch:  x86_64 aarch64
 
@@ -29,7 +32,6 @@ BuildRequires:  postgresql%{pg_version}-devel
 BuildRequires:  libicu-devel
 BuildRequires:  krb5-devel
 BuildRequires:  pcre2-devel
-BuildRequires:  pcre2-static
 BuildRequires:  openssl-devel
 BuildRequires:  rust
 BuildRequires:  cargo
@@ -50,6 +52,7 @@ Requires:       postgis36_%{pg_version}
 
 Provides:       bundled(libbson) = %{libbson_version}
 Provides:       bundled(intelmathlib) = %{intelmathlib_version}
+Provides:       bundled(pcre2) = %{pcre2_version}
 
 %description
 DocumentDB is the open-source engine powering Azure DocumentDB.
@@ -95,6 +98,7 @@ the gateway binary, and the PostgreSQL server.
 # Extract vendored dependency sources inside the main source tree
 tar xf %{SOURCE1}
 tar xf %{SOURCE2}
+tar xf %{SOURCE4}
 
 # Set up Cargo vendored dependencies for the gateway build
 pushd pg_documentdb_gw
@@ -156,12 +160,30 @@ Cflags: -I\${includedir}
 Libs: -L\${libdir} -lbid
 EOF
 
-# ---- 3. Build C PostgreSQL extensions ----
+# ---- 3. Build vendored pcre2 static library (avoids pcre2-static dep on EL9) ----
+mkdir -p pcre2-%{pcre2_version}/build
+pushd pcre2-%{pcre2_version}/build
+cmake \
+    -DCMAKE_C_FLAGS="-fPIC" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${_vendored} \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DPCRE2_BUILD_PCRE2_8=ON \
+    -DPCRE2_BUILD_PCRE2_16=OFF \
+    -DPCRE2_BUILD_PCRE2_32=OFF \
+    -DPCRE2_BUILD_PCRE2GREP=OFF \
+    -DPCRE2_BUILD_TESTS=OFF \
+    ..
+make %{?_smp_mflags} install
+popd
+
+# ---- 4. Build C PostgreSQL extensions ----
 export PKG_CONFIG_PATH=${_vendored}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
 make %{?_smp_mflags} \
     PG_CONFIG=/usr/pgsql-%{pg_version}/bin/pg_config
 
-# ---- 4. Build gateway binary ----
+# ---- 5. Build gateway binary ----
 cd pg_documentdb_gw
 cargo build --release
 cd ..

--- a/packaging/rpm/spec/documentdb-copr.spec
+++ b/packaging/rpm/spec/documentdb-copr.spec
@@ -84,6 +84,10 @@ Requires:       postgresql%{pg_version}-server
 Meta-package that pulls in all DocumentDB components: the PostgreSQL extensions,
 the gateway binary, and the PostgreSQL server.
 
+# PGDG installs to /usr/pgsql-18/lib which triggers Fedora's RPATH check
+# (error 0x0002: "standard library path"). This is expected for PGDG extensions.
+%global __brp_check_rpaths QA_RPATHS=0x0002 /usr/lib/rpm/check-rpaths
+
 # ===========================================================================
 %prep
 %setup -q

--- a/packaging/rpm/spec/documentdb-copr.spec
+++ b/packaging/rpm/spec/documentdb-copr.spec
@@ -297,4 +297,5 @@ rm -rf %{buildroot}/usr/src/documentdb/pg_documentdb_gw/vendor
 - Skip loading documents if group expression is constant *[Perf]*
 - Fix Merge stage not outputing to target collection *[Bugfix]* (#20)
 
-* Thu Jan 23 2025 Shuai Tian
+* Thu Jan 23 2025 Shuai Tian <shuaitian@microsoft.com> - 0.100-0
+- Initial Release

--- a/packaging/rpm/spec/documentdb-copr.spec
+++ b/packaging/rpm/spec/documentdb-copr.spec
@@ -1,0 +1,300 @@
+%global pg_version 18
+%global libbson_version 1.28.0
+%global intelmathlib_version 2.0u3-1
+
+%define debug_package %{nil}
+
+Name:           postgresql%{pg_version}-documentdb
+Version:        0.111.0
+Release:        1%{?dist}
+Summary:        DocumentDB — document-oriented NoSQL engine for PostgreSQL
+
+License:        MIT
+URL:            https://github.com/documentdb/documentdb
+Source0:        %{name}-%{version}.tar.gz
+Source1:        https://github.com/mongodb/mongo-c-driver/releases/download/%{libbson_version}/mongo-c-driver-%{libbson_version}.tar.gz
+# Generate: git clone --depth 1 -b applied/2.0u3-1 https://git.launchpad.net/ubuntu/+source/intelrdfpmath intelrdfpmath-2.0u3-1 && tar czf intelrdfpmath-2.0u3-1.tar.gz intelrdfpmath-2.0u3-1
+Source2:        intelrdfpmath-%{intelmathlib_version}.tar.gz
+# Generate: cd pg_documentdb_gw && cargo vendor && tar czf ../documentdb-gateway-vendor.tar.gz vendor/
+Source3:        documentdb-gateway-vendor.tar.gz
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  make
+BuildRequires:  cmake
+BuildRequires:  pkg-config
+BuildRequires:  postgresql%{pg_version}-devel
+BuildRequires:  libicu-devel
+BuildRequires:  krb5-devel
+BuildRequires:  pcre2-devel
+BuildRequires:  pcre2-static
+BuildRequires:  openssl-devel
+BuildRequires:  rust
+BuildRequires:  cargo
+BuildRequires:  cyrus-sasl-devel
+BuildRequires:  snappy-devel
+BuildRequires:  zlib-devel
+BuildRequires:  libcurl-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  lz4-devel
+BuildRequires:  bzip2-devel
+
+Requires:       postgresql%{pg_version}
+Requires:       postgresql%{pg_version}-server
+Requires:       pgvector_%{pg_version}
+Requires:       pg_cron_%{pg_version}
+Requires:       postgis36_%{pg_version}
+# rum_18 is NOT required — documentdb_extended_rum replaces it for PG 18+
+
+Provides:       bundled(libbson) = %{libbson_version}
+Provides:       bundled(intelmathlib) = %{intelmathlib_version}
+
+%description
+DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for
+MongoDB. It offers a native implementation of document-oriented NoSQL database,
+enabling seamless CRUD operations on BSON data types within a PostgreSQL
+framework.
+
+This package contains the PostgreSQL extensions: documentdb_core, documentdb,
+and documentdb_extended_rum.
+
+# ---------------------------------------------------------------------------
+# Subpackage: documentdb-gateway
+# ---------------------------------------------------------------------------
+%package -n documentdb-gateway
+Summary:        DocumentDB Gateway — MongoDB wire protocol proxy
+Requires:       openssl-libs
+
+%description -n documentdb-gateway
+The DocumentDB Gateway is a Rust-based proxy that implements the MongoDB wire
+protocol and translates requests to the DocumentDB PostgreSQL extensions.
+
+# ---------------------------------------------------------------------------
+# Subpackage: documentdb-server (meta-package)
+# ---------------------------------------------------------------------------
+%package -n documentdb-server
+Summary:        DocumentDB Server — complete installation meta-package
+Requires:       %{name} = %{version}-%{release}
+Requires:       documentdb-gateway = %{version}-%{release}
+Requires:       postgresql%{pg_version}-server
+
+%description -n documentdb-server
+Meta-package that pulls in all DocumentDB components: the PostgreSQL extensions,
+the gateway binary, and the PostgreSQL server.
+
+# ===========================================================================
+%prep
+%setup -q
+
+# Extract vendored dependency sources inside the main source tree
+tar xf %{SOURCE1}
+tar xf %{SOURCE2}
+
+# Set up Cargo vendored dependencies for the gateway build
+pushd pg_documentdb_gw
+tar xf %{SOURCE3}
+mkdir -p .cargo
+cat > .cargo/config.toml << 'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+popd
+
+# Remove internal/ (proprietary pg_documentdb_distributed) from build targets
+sed -i '/internal/d' Makefile
+
+# Strip -Werror from all Makefiles to avoid build failures with newer GCC on Fedora.
+# This must be done here rather than via a PG_CFLAGS command-line override because
+# sub-Makefiles append to PG_CFLAGS (e.g. -DCROARING_ATOMIC_IMPL=3 in pg_documentdb/).
+sed -i 's/-Werror //g' Makefile.cflags pg_documentdb_extended_rum/core/Makefile
+
+# ===========================================================================
+%build
+_vendored=$(pwd)/_vendored
+mkdir -p ${_vendored}/lib/pkgconfig
+
+# ---- 1. Build vendored libbson from mongo-c-driver ----
+mkdir -p mongo-c-driver-%{libbson_version}/build
+pushd mongo-c-driver-%{libbson_version}/build
+cmake \
+    -DENABLE_MONGOC=ON \
+    -DMONGOC_ENABLE_ICU=OFF \
+    -DENABLE_ICU=OFF \
+    -DCMAKE_C_FLAGS="-fPIC -g" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${_vendored} \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    ..
+make %{?_smp_mflags} install
+popd
+
+# ---- 2. Build vendored Intel Decimal Math Library ----
+pushd intelrdfpmath-%{intelmathlib_version}/LIBRARY
+make %{?_smp_mflags} _CFLAGS_OPT=-fPIC CC=gcc \
+    CALL_BY_REF=0 GLOBAL_RND=0 GLOBAL_FLAGS=0 UNCHANGED_BINARY_FLAGS=0
+popd
+
+# Create intelmathlib pkg-config file pointing at the source build tree
+cat > ${_vendored}/lib/pkgconfig/intelmathlib.pc << EOF
+prefix=$(pwd)/intelrdfpmath-%{intelmathlib_version}
+libdir=\${prefix}/LIBRARY
+includedir=\${prefix}/LIBRARY/src
+
+Name: intelmathlib
+Description: Intel Decimal Floating point math library
+Version: 2.0 Update 2
+Cflags: -I\${includedir}
+Libs: -L\${libdir} -lbid
+EOF
+
+# ---- 3. Build C PostgreSQL extensions ----
+export PKG_CONFIG_PATH=${_vendored}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
+make %{?_smp_mflags} \
+    PG_CONFIG=/usr/pgsql-%{pg_version}/bin/pg_config
+
+# ---- 4. Build gateway binary ----
+cd pg_documentdb_gw
+cargo build --release
+cd ..
+
+# ===========================================================================
+%install
+_vendored=$(pwd)/_vendored
+export PKG_CONFIG_PATH=${_vendored}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
+
+# ---- Install C extensions via PGXS ----
+make install DESTDIR=%{buildroot} \
+    PG_CONFIG=/usr/pgsql-%{pg_version}/bin/pg_config
+
+# Remove LLVM/JIT bitcode directory
+rm -rf %{buildroot}/usr/pgsql-%{pg_version}/lib/bitcode
+
+# ---- Bundle vendored libbson shared libraries ----
+mkdir -p %{buildroot}%{_libdir}/pkgconfig
+cp    ${_vendored}/lib/libbson-1.0.so.0.0.0   %{buildroot}%{_libdir}/
+cp -P ${_vendored}/lib/libbson-1.0.so.0       %{buildroot}%{_libdir}/
+cp -P ${_vendored}/lib/libbson-1.0.so         %{buildroot}%{_libdir}/
+cp    ${_vendored}/lib/pkgconfig/libbson-static-1.0.pc %{buildroot}%{_libdir}/pkgconfig/
+
+# ---- Bundle Intel Decimal Math Library static lib ----
+mkdir -p %{buildroot}/usr/lib/intelmathlib/LIBRARY
+cp intelrdfpmath-%{intelmathlib_version}/LIBRARY/libbid.a \
+   %{buildroot}/usr/lib/intelmathlib/LIBRARY/
+
+# ---- Install gateway binary ----
+install -D -m 0755 pg_documentdb_gw/target/release/documentdb_gateway \
+    %{buildroot}%{_bindir}/documentdb_gateway
+
+# ---- Bundle source code for make check ----
+mkdir -p %{buildroot}/usr/src/documentdb
+cp -r . %{buildroot}/usr/src/documentdb/
+# Clean up build artifacts and vendored build trees from the source copy
+find %{buildroot}/usr/src/documentdb -name "*.o" -delete
+find %{buildroot}/usr/src/documentdb -name "*.so" -delete
+find %{buildroot}/usr/src/documentdb -name "*.bc" -delete
+rm -rf %{buildroot}/usr/src/documentdb/.git*
+rm -rf %{buildroot}/usr/src/documentdb/build
+rm -rf %{buildroot}/usr/src/documentdb/_vendored
+rm -rf %{buildroot}/usr/src/documentdb/mongo-c-driver-%{libbson_version}
+rm -rf %{buildroot}/usr/src/documentdb/intelrdfpmath-%{intelmathlib_version}
+rm -rf %{buildroot}/usr/src/documentdb/pg_documentdb_gw/target
+rm -rf %{buildroot}/usr/src/documentdb/pg_documentdb_gw/vendor
+
+# ===========================================================================
+%files
+%license LICENSE
+%defattr(-,root,root,-)
+/usr/pgsql-%{pg_version}/lib/*.so
+/usr/pgsql-%{pg_version}/share/extension/*.control
+/usr/pgsql-%{pg_version}/share/extension/*.sql
+/usr/src/documentdb
+/usr/lib/intelmathlib/LIBRARY/libbid.a
+%{_libdir}/libbson-1.0.so
+%{_libdir}/libbson-1.0.so.0
+%{_libdir}/libbson-1.0.so.0.0.0
+%{_libdir}/pkgconfig/libbson-static-1.0.pc
+
+%files -n documentdb-gateway
+%license LICENSE
+%{_bindir}/documentdb_gateway
+
+%files -n documentdb-server
+%license LICENSE
+
+# ===========================================================================
+%changelog
+* Mon Mar 09 2026 Shuai Tian <shuaitian@microsoft.com> - 0.111.0-1
+- Update to version 0.111.0
+
+* Fri Aug 29 2025 Shuai Tian <shuaitian@microsoft.com> - 0.106-0
+- Add internal extension that provides extensions to the `rum` index. *[Feature]*
+- Enable let support for update queries *[Feature]*. Requires `EnableVariablesSupportForWriteCommands` to be `on`.
+- Enable let support for findAndModify queries *[Feature]*. Requires `EnableVariablesSupportForWriteCommands` to be `on`.
+- Add internal extension that provides extensions to the `rum` index. *[Feature]*
+- Optimized query for `usersInfo` command.
+- Support collation with `delete` *[Feature]*. Requires `EnableCollation` to be `on`.
+- Support for index hints for find/aggregate/count/distinct *[Feature]*
+- Support `createRole` command *[Feature]*
+- Add schema changes for Role CRUD APIs *[Feature]*
+- Add support for using EntraId tokens via Plain Auth
+
+* Mon Jul 28 2025 Shuai Tian <shuaitian@microsoft.com> - 0.105-0
+- Support `$bucketAuto` aggregation stage, with granularity types: `POWERSOF2`, `1-2-5`, `R5`, `R10`, `R20`, `R40`, `R80`, `E6`, `E12`, `E24`, `E48`, `E96`, `E192` *[Feature]*
+- Support `conectionStatus` command *[Feature]*.
+
+* Mon Jun 09 2025 Shuai Tian <shuaitian@microsoft.com> - 0.104-0
+- Add string case support for `$toDate` operator
+- Support `sort` with collation in runtime*[Feature]*
+- Support collation with `$indexOfArray` aggregation operator. *[Feature]*
+- Support collation with arrays and objects comparisons *[Feature]*
+- Support background index builds *[Bugfix]* (#36)
+- Enable user CRUD by default *[Feature]*
+- Enable let support for delete queries *[Feature]*. Requires `EnableVariablesSupportForWriteCommands` to be `on`.
+- Enable rum_enable_index_scan as default on *[Perf]*
+- Add public `documentdb-local` Docker image with gateway to GHCR
+- Support `compact` command *[Feature]*. Requires `documentdb.enablecompact` GUC to be `on`.
+- Enable role privileges for `usersInfo` command *[Feature]* 
+
+* Fri May 09 2025 Shuai Tian <shuaitian@microsoft.com> - 0.103-0
+- Support collation with aggregation and find on sharded collections *[Feature]*
+- Support `$convert` on `binData` to `binData`, `string` to `binData` and `binData` to `string` (except with `format: auto`) *[Feature]*
+- Fix list_databases for databases with size > 2 GB *[Bugfix]* (#119)
+- Support half-precision vector indexing, vectors can have up to 4,000 dimensions *[Feature]*
+- Support ARM64 architecture when building docker container *[Preview]*
+- Support collation with `$documents` and `$replaceWith` stage of the aggregation pipeline *[Feature]*
+- Push pg_documentdb_gw for documentdb connections *[Feature]*
+
+* Wed Mar 26 2025 Shuai Tian <shuaitian@microsoft.com> - 0.102-0
+- Support index pushdown for vector search queries *[Bugfix]*
+- Support exact search for vector search queries *[Feature]*
+- Inline $match with let in $lookup pipelines as JOIN Filter *[Perf]*
+- Support TTL indexes *[Bugfix]* (#34)
+- Support joining between postgres and documentdb tables *[Feature]* (#61)
+- Support current_op command *[Feature]* (#59)
+- Support for list_databases command *[Feature]* (#45)
+- Disable analyze statistics for unique index uuid columns which improves resource usage *[Perf]*
+- Support collation with `$expr`, `$in`, `$cmp`, `$eq`, `$ne`, `$lt`, `$lte`, `$gt`, `$gte` comparison operators (Opt-in) *[Feature]*
+- Support collation in `find`, aggregation `$project`, `$redact`, `$set`, `$addFields`, `$replaceRoot` stages (Opt-in) *[Feature]*
+- Support collation with `$setEquals`, `$setUnion`, `$setIntersection`, `$setDifference`, `$setIsSubset` in the aggregation pipeline (Opt-in) *[Feature]*
+- Support unique index truncation by default with new operator class *[Feature]*
+- Top level aggregate command `let` variables support for `$geoNear` stage *[Feature]*
+- Enable Backend Command support for Statement Timeout *[Feature]*
+- Support type aggregation operator `$toUUID`. *[Feature]*
+- Support Partial filter pushdown for `$in` predicates *[Perf]*
+- Support the $dateFromString operator with full functionality *[Feature]*
+- Support extended syntax for `$getField` aggregation operator. Now the value of 'field' could be an expression that resolves to a string. *[Feature]*
+
+* Wed Feb 12 2025 Shuai Tian <shuaitian@microsoft.com> - 0.101-0
+- Push $graphlookup recursive CTE JOIN filters to index *[Perf]*
+- Build pg_documentdb for PostgreSQL 17 *[Infra]* (#13)
+- Enable support of currentOp aggregation stage, along with collstats, dbstats, and indexStats *[Commands]* (#52)
+- Allow inlining $unwind with $lookup with `preserveNullAndEmptyArrays` *[Perf]*
+- Skip loading documents if group expression is constant *[Perf]*
+- Fix Merge stage not outputing to target collection *[Bugfix]* (#20)
+
+* Thu Jan 23 2025 Shuai Tian

--- a/packaging/rpm/spec/documentdb.spec
+++ b/packaging/rpm/spec/documentdb.spec
@@ -4,7 +4,7 @@
 Name:           postgresql%{pg_version}-documentdb
 Version:        DOCUMENTDB_VERSION
 Release:        1%{?dist}
-Summary:        DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for MongoDB
+Summary:        DocumentDB is the open-source engine powering Azure DocumentDB
 
 License:        MIT
 URL:            https://github.com/microsoft/documentdb
@@ -36,7 +36,7 @@ Requires:       rum_%{pg_version}
 # libbid.a is bundled.
 
 %description
-DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for MongoDB. 
+DocumentDB is the open-source engine powering Azure DocumentDB. 
 It offers a native implementation of document-oriented NoSQL database, enabling seamless 
 CRUD operations on BSON data types within a PostgreSQL framework.
 

--- a/packaging/test_copr_srpm.sh
+++ b/packaging/test_copr_srpm.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Test the Copr SRPM build locally in a Fedora container.
+# This replicates the Copr mock chroot environment to catch errors
+# before pushing to the remote Copr project.
+#
+# Usage: ./packaging/test_copr_srpm.sh [--output-dir DIR]
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:+${1#--output-dir=}}"
+OUTPUT_DIR="${OUTPUT_DIR:-$script_dir/packaging}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            shift
+            OUTPUT_DIR="$1"
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--output-dir DIR]"
+            echo ""
+            echo "Test the Copr SRPM build locally using a Fedora container."
+            echo ""
+            echo "Options:"
+            echo "  --output-dir DIR  Directory to place the built SRPM (default: packaging/)"
+            echo "  -h, --help        Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+abs_output_dir="$(cd "$script_dir" && mkdir -p "$OUTPUT_DIR" && cd "$OUTPUT_DIR" && pwd)"
+
+echo "=== Testing Copr SRPM build in Fedora container ==="
+echo "Source directory: $script_dir"
+echo "Output directory: $abs_output_dir"
+
+docker run --rm \
+    -v "$script_dir:/src:z" \
+    -v "$abs_output_dir:/output:z" \
+    fedora:latest \
+    bash -c '
+        set -euo pipefail
+        echo "--- Installing base tools ---"
+        dnf install -y rpm-build curl make 2>&1 | tail -1
+
+        cd /src
+        echo "--- Running .copr/Makefile srpm target ---"
+        make -f .copr/Makefile srpm outdir=/output
+
+        echo ""
+        echo "=== SRPM build succeeded ==="
+        ls -lh /output/*.src.rpm
+    '
+
+echo ""
+echo "SRPM available in: $abs_output_dir"
+ls -lh "$abs_output_dir"/*.src.rpm 2>/dev/null

--- a/rfcs/0005-functional-testing.md
+++ b/rfcs/0005-functional-testing.md
@@ -208,7 +208,7 @@ docker run documentdb/functional-tests \
   --connection-string mongodb://cluster.docdb.amazonaws.com:27017 \
   --engine-name amazon-documentdb
 
-# Azure Cosmos DB (MongoDB API)
+# Azure DocumentDB
 docker run documentdb/functional-tests \
   --connection-string mongodb://myaccount.mongo.cosmos.azure.com:27017 \
   --engine-name microsoft-documentdb


### PR DESCRIPTION
## Summary

   Adds Fedora Copr integration to distribute DocumentDB as RPM packages, and updates branding from "Azure Cosmos DB for MongoDB" to
  "Azure DocumentDB".

   ## Packages produced

   A single SRPM builds three binary RPMs:

   | Package | Contents |
   |---------|----------|
   | `postgresql18-documentdb` | PostgreSQL extensions: `documentdb_core`, `documentdb`, `documentdb_extended_rum` |
   | `documentdb-gateway` | MongoDB wire protocol gateway binary |
   | `documentdb-server` | Meta-package that installs everything |

   ## New files

   - **`packaging/rpm/spec/documentdb-copr.spec`** — Copr-compatible spec file. Builds vendored libbson and Intel Decimal Math Library
  in-tree; uses system `pcre2-devel`. Targets PG 18 on Fedora via PGDG external repo.
   - **`.copr/Makefile`** — `srpm` target for Copr SCM integration. Downloads vendored sources, creates cargo vendor tarball, and produces
   the SRPM.
   - **`packaging/README.md`** — Documents Copr project setup, external repo config, and user installation.

   ## Branding update

   Replaces "vCore-based Azure Cosmos DB for MongoDB" with "Azure DocumentDB" across packaging and documentation files.