### PR TITLE
BugFix gateway type inference error in extension_versions query

### DIFF
--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
@@ -559,7 +559,7 @@ pub fn create_query_catalog() -> QueryCatalog {
                              GRANT documentdb_admin_role TO {user} WITH ADMIN OPTION".to_string(),
 
             // version.rs
-            extension_versions: "SELECT documentdb_core.bson_build_document('internal', ARRAY[ (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version() ])".to_string(),
+            extension_versions: "SELECT documentdb_core.bson_build_document('internal'::text, ARRAY[ (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version() ])".to_string(),
 
             // scan_types
             scan_types: vec![


### PR DESCRIPTION
# Bug Fix: Gateway Background Worker Type Inference Error

## Issue Description

Gateway background worker logs continuous errors when attempting to load topology version information due to PostgreSQL type inference error in the `extension_versions` query. The `bson_build_document` function receives string literal parameters with `unknown` type, causing a type validation error.

**Note**: This issue does not prevent the gateway from starting, but results in repeated error logs and prevents topology information from being loaded correctly.

## Environment

- **Operating System**: Linux
- **PostgreSQL Version**: 16
- **DocumentDB Version**: 0.110-0
- **Component**: pg_documentdb_gw (Background Worker)
- **Affected File**: `contrib/documentdb/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs`

## Steps to Reproduce

1. Start DocumentDB Docker container:
   ```bash
   docker run -d --name documentdb-test \
     -p 9712:27017 \
     -p 5432:5432 \
     documentdb/documentdb:latest
   ```

2. Connect to PostgreSQL inside the container:
   ```bash
   docker exec -it documentdb-test bash
   psql -d postgres -p 9712
   ```

3. Execute the problematic query:
   ```bash
      documentdb@8617d718218b:~/gateway/scripts$ psql -d postgres -p 9712
      SET
      SET
      psql (17.9 (Debian 17.9-1.pgdg13+1))
      Type "help" for help.

      postgres=# SELECT documentdb_core.bson_build_document('internal', ARRAY[ (SELECT extversion
      FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version()])
      ;
      ERROR:  Invalid type: expected a text type field, but received unknown instead
      postgres=# SELECT documentdb_core.bson_build_document('internal'::text, ARRAY[ (SELECT extve
      rsion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version
      ()])
      ;
                  bson_build_document
      -------------------------------------------
      { "internal" : [ "0.109-0", "0.109.0" ] }
      (1 row)

      postgres=# quit
   ```

4. Observe the error:
   ```
   ERROR:  Invalid type: expected a text type field, but received unknown instead
   ```

5. Verify the fix works:
   ```sql
   SELECT documentdb_core.bson_build_document(
       'internal'::text,
       ARRAY[
           (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1),
           documentdb_api.binary_version()
       ]
   );
   ```

6. Expected output:
   ```
   bson_build_document
   -------------------------------------------
   { "internal" : [ "0.109-0", "0.109.0" ] }
   (1 row)
   ```

## Expected Behavior

The gateway background worker should:
- Start successfully alongside PostgreSQL
- Load topology version information from the database
- Execute the `extension_versions` query without errors
- Log successful topology acquisition: `"Topology acquired: ..."`

## Actual Behavior

The background worker starts but continuously logs errors when attempting to load topology information:

```
2026-03-10T03:26:31.964290Z ERROR ThreadId(01) documentdb_gateway_core::configuration::pg_configuration:
Failed to load topology versions: PostgresError {
  sql_state: SqlState(Other("M0001")),
  hint: None,
  file: Some("bson_io.c"),
  line_num: Some(440),
  backtrace: <disabled>
}
```

Error details:
- **SQL State**: M0001 (ERRCODE_DOCUMENTDB_BADVALUE)
- **Source**: `bson_io.c:440`
- **Message**: "Invalid type: expected a text type field, but received unknown instead"

### Error Handling Behavior

The error is caught and handled gracefully:
```rust
Err(e) => {
    tracing::error!("Failed to load topology versions: {e}");
    return rawbson!({});  // Returns empty BSON document
}
```

This means:
- Gateway continues to run
- Topology information is not available (empty document returned)
- Error is logged repeatedly on each topology load attempt
- No crash or service interruption occurs

## Root Cause Analysis

### PostgreSQL Type Inference Issue

The problematic query in `query_catalog.rs` (line 562):

```sql
SELECT documentdb_core.bson_build_document(
    'internal',
    ARRAY[
        (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1),
        documentdb_api.binary_version()
    ]
)
```

### Why This Fails

1. **VARIADIC Function Signature**:
   ```sql
   CREATE FUNCTION bson_build_document(VARIADIC "any") RETURNS bson
   ```
   - Accepts any number and type of arguments
   - No automatic type inference for parameters

2. **String Literal Type**:
   - `'internal'` is treated as `unknown` type by PostgreSQL
   - Without context, PostgreSQL doesn't know if it's text, varchar, or other string type

3. **Function Validation**:
   - `bson_build_document` expects keys (odd-position arguments) to be `text` type
   - The function's internal validation at `bson_io.c:440` rejects `unknown` type
   - Error: "Invalid type: expected a text type field, but received unknown instead"

### Type Inference Behavior

```sql
-- Demonstrates the issue
SELECT pg_typeof('internal');           -- Returns: unknown
SELECT pg_typeof('internal'::text);     -- Returns: text

-- This fails
SELECT documentdb_core.bson_build_document('internal', ARRAY['a', 'b']);
-- ERROR: Invalid type: expected a text type field, but received unknown instead

-- This works
SELECT documentdb_core.bson_build_document('internal'::text, ARRAY['a', 'b']);
-- Returns: { "internal" : [ "a", "b" ] }
```

## Solution

Add explicit `::text` type cast to the first parameter (the key):

```sql
SELECT documentdb_core.bson_build_document(
    'internal'::text,
    ARRAY[
        (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1),
        documentdb_api.binary_version()
    ]
)
```

### Why Only the First Parameter Needs Casting

- **Keys must be text**: The first parameter is a key in the BSON document and must be explicitly typed as `text`
- **Values are flexible**: The second parameter (ARRAY) can be any type; PostgreSQL's ARRAY constructor handles internal type inference
- **Minimal change**: Only the string literal key needs explicit casting

## Code Changes

**File**: `contrib/documentdb/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs`

**Line**: 562

**Before**:
```rust
extension_versions: "SELECT documentdb_core.bson_build_document('internal', ARRAY[ (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version() ])".to_string(),
```

**After**:
```rust
extension_versions: "SELECT documentdb_core.bson_build_document('internal'::text, ARRAY[ (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version() ])".to_string(),
```

**Change Summary**: Added `::text` cast to `'internal'` parameter

## Verification

### Test Query

```sql
-- Test the broken query (before fix)
SELECT documentdb_core.bson_build_document(
    'internal',
    ARRAY[
        (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1),
        documentdb_api.binary_version()
    ]
);
-- ERROR:  Invalid type: expected a text type field, but received unknown instead

-- Test the fixed query (after fix)
SELECT documentdb_core.bson_build_document(
    'internal'::text,
    ARRAY[
        (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1),
        documentdb_api.binary_version()
    ]
);
-- Expected output:
-- { "internal" : [ "0.109-0", "0.109.0" ] }  (version may vary)
```

### Docker Environment Test Session

Reproduction using DocumentDB Docker image:

```
documentdb@8617d718218b:~/gateway/scripts$ psql -d postgres -p 9712
SET
SET
psql (17.9 (Debian 17.9-1.pgdg13+1))
Type "help" for help.

postgres=# SELECT documentdb_core.bson_build_document('internal', ARRAY[ (SELECT extversion
FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version()]);
ERROR:  Invalid type: expected a text type field, but received unknown instead

postgres=# SELECT documentdb_core.bson_build_document('internal'::text, ARRAY[ (SELECT extversion FROM pg_extension WHERE extname = 'documentdb' LIMIT 1), documentdb_api.binary_version()]);
         bson_build_document
-------------------------------------------
 { "internal" : [ "0.109-0", "0.109.0" ] }
(1 row)

postgres=#
```

### Testing Steps

1. Apply the code change
2. Rebuild the gateway component:
   ```bash
   cd contrib/documentdb/pg_documentdb_gw
   cargo build --release
   ```
3. Install the updated library:
   ```bash
   make install
   ```
4. Restart PostgreSQL
5. Verify gateway worker starts without errors
6. Check logs for successful topology loading:
   ```
   Topology acquired: { "internal" : [ "0.110-0", "0.110.0" ] }
   ```

## Related Information

### PostgreSQL Type System

- String literals without context are typed as `unknown`
- VARIADIC functions with `"any"` type don't provide type context
- Explicit casting (`::type`) forces type resolution

### Function Signature

```sql
-- bson_build_document expects alternating key-value pairs
-- Keys (odd positions): must be text or coercible to text
-- Values (even positions): can be any type including bson, arrays, etc.

bson_build_document(key1::text, value1, key2::text, value2, ...)
```

### Similar Issues

This pattern affects any VARIADIC function that:
- Accepts `"any"` type parameters
- Has internal type validation
- Receives string literals without explicit casting

## Impact

- **Severity**: Medium - gateway runs but logs errors and lacks topology information
- **Scope**: All deployments using pg_documentdb_gw_host background worker
- **User Impact**:
  - Continuous error logs pollute log files
  - Topology version information unavailable
  - No functional impact on gateway operation
- **Workaround**: None (requires code fix)

## Fix Status

- **Status**: Fixed
- **Date**: 2026-03-10
- **Fix Type**: Type casting correction
- **Testing**: Verified with manual SQL query execution
