### PR TITLE
Add version check to enable backward compatible Gateway-Extension BSO…

### DIFF
--- a/pg_documentdb/src/configs/feature_flag_configs.c
+++ b/pg_documentdb/src/configs/feature_flag_configs.c
@@ -387,6 +387,14 @@ bool EnableDropInvalidIndexesOnReadOnly = DEFAULT_ENABLE_DROP_INDEXES_ON_READ_ON
 #define DEFAULT_INDEX_BUILDS_SCHEDULED_ON_BGWORKER false
 bool IndexBuildsScheduledOnBgWorker = DEFAULT_INDEX_BUILDS_SCHEDULED_ON_BGWORKER;
 
+/*
+ * SECTION: Gateway-Extension compatibility flags
+ */
+
+/* Added in v111, Pending stabilization */
+#define DEFAULT_ENABLE_BSON_PASSTHROUGH_COMMANDS false
+bool EnableBsonPassthroughCommands = DEFAULT_ENABLE_BSON_PASSTHROUGH_COMMANDS;
+
 /* FEATURE FLAGS END */
 
 void
@@ -970,5 +978,14 @@ InitializeFeatureFlagConfigurations(const char *prefix, const char *newGucPrefix
 			"Whether to enable dropping invalid indexes on read only database state."),
 		NULL, &EnableDropInvalidIndexesOnReadOnly,
 		DEFAULT_ENABLE_DROP_INDEXES_ON_READ_ONLY,
+		PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
+		psprintf("%s.enableBsonPassthroughCommands", newGucPrefix),
+		gettext_noop(
+			"Enables BSON passthrough mode for gateway commands that depend on newer extension versions."),
+		NULL,
+		&EnableBsonPassthroughCommands,
+		DEFAULT_ENABLE_BSON_PASSTHROUGH_COMMANDS,
 		PGC_USERSET, 0, NULL, NULL, NULL);
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/configuration/dynamic.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/configuration/dynamic.rs
@@ -14,6 +14,15 @@ use crate::{configuration::Version, postgres::conn_mgmt};
 
 pub const POSTGRES_RECOVERY_KEY: &str = "IsPostgresInRecovery";
 
+/// Parses "major.minor-patch" or "major.minor.patch" format into (major, minor).
+pub fn parse_extension_version(version_str: &str) -> Option<(u32, u32)> {
+    let (major_str, rest) = version_str.split_once('.')?;
+    let major = major_str.parse().ok()?;
+    let minor_str = rest.split(['-', '.']).next()?;
+    let minor = minor_str.parse().ok()?;
+    Some((major, minor))
+}
+
 /// Used for configurations which can change during runtime.
 pub trait DynamicConfiguration: Send + Sync + Debug {
     fn get_str(&self, key: &str) -> Option<String>;
@@ -143,5 +152,33 @@ pub trait DynamicConfiguration: Send + Sync + Debug {
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "")
+    }
+
+    /// Returns true if the GUC enableBsonPassthroughCommands is ON and the Extension
+    /// version is >= 0.110 (the version where BSON command signatures were introduced).
+    fn extension_supports_bson_passthrough(&self) -> bool {
+        if !self.get_bool("enableBsonPassthroughCommands", false) {
+            return false;
+        }
+        let topology = self.topology();
+        let raw_doc = match topology.as_document() {
+            Some(d) => d,
+            None => return false,
+        };
+        let versions = match raw_doc.get_array("documentdb_versions") {
+            Ok(arr) => arr,
+            Err(_) => return false,
+        };
+        let version_str = match versions.into_iter().next() {
+            Some(Ok(v)) => match v.as_str() {
+                Some(s) => s,
+                None => return false,
+            },
+            _ => return false,
+        };
+        match parse_extension_version(version_str) {
+            Some((major, minor)) => major > 0 || (major == 0 && minor >= 110),
+            None => false,
+        }
     }
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/data_client.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/data_client.rs
@@ -258,6 +258,16 @@ pub trait PgDataClient: Send + Sync {
         connection_context: &ConnectionContext,
     ) -> Result<Vec<Row>>;
 
+    async fn execute_rename_collection_legacy(
+        &self,
+        request_context: &RequestContext<'_>,
+        source_db: &str,
+        source_coll: &str,
+        target_coll: &str,
+        drop_target: bool,
+        connection_context: &ConnectionContext,
+    ) -> Result<Vec<Row>>;
+
     async fn execute_create_user(
         &self,
         request_context: &RequestContext<'_>,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/documentdb_data_client.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/documentdb_data_client.rs
@@ -953,6 +953,34 @@ impl PgDataClient for DocumentDBDataClient {
         Ok(rename_collection_rows)
     }
 
+    async fn execute_rename_collection_legacy(
+        &self,
+        request_context: &RequestContext<'_>,
+        source_db: &str,
+        source_coll: &str,
+        target_coll: &str,
+        drop_target: bool,
+        connection_context: &ConnectionContext,
+    ) -> Result<Vec<Row>> {
+        let (_, request_info, request_tracker) = request_context.get_components();
+        let rename_collection_rows = self
+            .pull_connection(connection_context)
+            .await?
+            .query(
+                connection_context
+                    .service_context
+                    .query_catalog()
+                    .rename_collection_legacy(),
+                &[Type::TEXT, Type::TEXT, Type::TEXT, Type::BOOL],
+                &[&source_db, &source_coll, &target_coll, &drop_target],
+                Timeout::transaction(request_info.max_time_ms),
+                request_tracker,
+            )
+            .await?;
+
+        Ok(rename_collection_rows)
+    }
+
     async fn execute_create_user(
         &self,
         request_context: &RequestContext<'_>,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
@@ -61,6 +61,7 @@ pub struct QueryCatalog {
     pub set_allow_write: String,
     pub shard_collection: String,
     pub rename_collection: String,
+    pub rename_collection_legacy: String,
     pub coll_mod: String,
     pub unshard_collection: String,
     pub get_shard_map: String,
@@ -356,6 +357,10 @@ impl QueryCatalog {
         &self.rename_collection
     }
 
+    pub fn rename_collection_legacy(&self) -> &str {
+        &self.rename_collection_legacy
+    }
+
     pub fn current_op(&self) -> &str {
         &self.current_op
     }
@@ -500,6 +505,7 @@ pub fn create_query_catalog() -> QueryCatalog {
             create_collection_view: "SELECT documentdb_api.create_collection_view($1, $2)".to_string(),
             shard_collection: "SELECT documentdb_api.shard_collection($1, $2, $3, $4)".to_string(),
             rename_collection: "SELECT documentdb_api.rename_collection($1)".to_string(),
+            rename_collection_legacy: "SELECT documentdb_api.rename_collection($1, $2, $3, $4)".to_string(),
             coll_mod: "SELECT documentdb_api.coll_mod($1, $2, $3)".to_string(),
             unshard_collection: "SELECT documentdb_api.unshard_collection($1)".to_string(),
 

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/data_description.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/data_description.rs
@@ -13,7 +13,7 @@ use bson::rawdoc;
 use crate::{
     configuration::DynamicConfiguration,
     context::{ConnectionContext, RequestContext},
-    error::{DocumentDBError, Result},
+    error::{DocumentDBError, ErrorCode, Result},
     postgres::PgDataClient,
     protocol::{self, OK_SUCCEEDED},
     responses::{RawResponse, Response},
@@ -114,6 +114,71 @@ pub async fn process_rename_collection(
 ) -> Result<Response> {
     pg_data_client
         .execute_rename_collection(request_context, connection_context)
+        .await?;
+    Ok(Response::ok())
+}
+
+pub async fn process_rename_collection_legacy(
+    request_context: &RequestContext<'_>,
+    connection_context: &ConnectionContext,
+    pg_data_client: &impl PgDataClient,
+) -> Result<Response> {
+    let request = request_context.payload;
+    let mut source: Option<String> = None;
+    let mut target: Option<String> = None;
+    let mut drop_target = false;
+    request.extract_fields(|k, v| {
+        match k {
+            "renameCollection" => {
+                source = Some(
+                    v.as_str()
+                        .ok_or(DocumentDBError::bad_value(
+                            "renameCollection was not a string".to_string(),
+                        ))?
+                        .to_string(),
+                )
+            }
+            "to" => {
+                target = Some(
+                    v.as_str()
+                        .ok_or(DocumentDBError::bad_value(
+                            "to was not a string".to_string(),
+                        ))?
+                        .to_string(),
+                )
+            }
+            "dropTarget" => {
+                drop_target = v.as_bool().unwrap_or(false);
+            }
+            _ => {}
+        };
+        Ok(())
+    })?;
+
+    let source = source.ok_or(DocumentDBError::bad_value(
+        "'renameCollection' missing".to_string(),
+    ))?;
+    let target = target.ok_or(DocumentDBError::bad_value("'to' missing".to_string()))?;
+
+    let (source_db, source_coll) = protocol::extract_database_and_collection_names(&source)?;
+    let (target_db, target_coll) = protocol::extract_database_and_collection_names(&target)?;
+
+    if source_db != target_db {
+        return Err(DocumentDBError::documentdb_error(
+            ErrorCode::CommandNotSupported,
+            "renameCollection cannot change databases".to_string(),
+        ));
+    }
+
+    pg_data_client
+        .execute_rename_collection_legacy(
+            request_context,
+            source_db,
+            source_coll,
+            target_coll,
+            drop_target,
+            connection_context,
+        )
         .await?;
     Ok(Response::ok())
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/process.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/process.rs
@@ -291,12 +291,21 @@ pub async fn process_request(
                 .await
             }
             RequestType::RenameCollection => {
-                data_description::process_rename_collection(
-                    request_context,
-                    connection_context,
-                    pg_data_client,
-                )
-                .await
+                if dynamic_config.extension_supports_bson_passthrough() {
+                    data_description::process_rename_collection(
+                        request_context,
+                        connection_context,
+                        pg_data_client,
+                    )
+                    .await
+                } else {
+                    data_description::process_rename_collection_legacy(
+                        request_context,
+                        connection_context,
+                        pg_data_client,
+                    )
+                    .await
+                }
             }
             RequestType::PrepareTransaction => constant::process_prepare_transaction(),
             RequestType::CommitTransaction => transaction::process_commit(connection_context).await,

--- a/pg_documentdb_gw/documentdb_tests/src/test_setup/postgres.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/test_setup/postgres.rs
@@ -61,6 +61,30 @@ pub fn get_pool_manager() -> Arc<PoolManager> {
     }))
 }
 
+pub async fn is_bson_passthrough_enabled() -> bool {
+    let pool_manager = get_pool_manager();
+    let conn = match pool_manager.system_requests_connection().await {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let rows = match conn
+        .query(
+            "SELECT setting FROM pg_settings WHERE name = 'documentdb.enableBsonPassthroughCommands'",
+            &[],
+            &[],
+            None,
+            &RequestTracker::new(),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    rows.first()
+        .map(|row| row.get::<_, String>(0) == "on")
+        .unwrap_or(false)
+}
+
 pub async fn create_user(user: &str, pass: &str) -> Result<()> {
     let pool_manager = get_pool_manager();
 

--- a/pg_documentdb_gw/documentdb_tests/tests/rename_collection_tests.rs
+++ b/pg_documentdb_gw/documentdb_tests/tests/rename_collection_tests.rs
@@ -6,7 +6,10 @@
  *-------------------------------------------------------------------------
  */
 
-use documentdb_tests::{commands::rename_collection, test_setup::initialize};
+use documentdb_tests::{
+    commands::rename_collection,
+    test_setup::{initialize, postgres},
+};
 use mongodb::error::Error;
 
 #[tokio::test]
@@ -49,6 +52,11 @@ async fn validate_rename_collection_not_found_error() -> Result<(), Error> {
 
 #[tokio::test]
 async fn validate_rename_collection_unknown_field_error() -> Result<(), Error> {
+    if !postgres::is_bson_passthrough_enabled().await {
+        // Unknown field validation is only enforced on the BSON path (GUC=on).
+        // On the legacy path, unknown fields are silently ignored by design.
+        return Ok(());
+    }
     let db = initialize::initialize_with_db("rename_tests_unknown_field").await?;
 
     rename_collection::validate_rename_collection_unknown_field_error(&db).await;


### PR DESCRIPTION
  - Add GUC enableBsonPassthroughCommands (default: off) in Extension
  - Parse Extension version from topology_bson in Gateway
  - Route commands to BSON or legacy path based on GUC + Extension version >= 0.110
  - Add is_bson_passthrough_enabled() test helper for conditional test skipping

Related to #492 