### PR TITLE
Improve documentdb-local sample data startup

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -122,7 +122,7 @@ ENV CERT_PATH="" \
     OWNER="documentdb" \
     PG_VERSION_USED="${POSTGRES_VERSION}" \
     ALLOW_EXTERNAL_CONNECTIONS="false" \
-    INIT_DATA="true" \
+    INIT_DATA="false" \
     INIT_DATA_PATH="/init_doc_db.d" \
     PATH=/usr/lib/postgresql/${POSTGRES_VERSION}/bin:$PATH
 

--- a/docs/v1/data-initialization.md
+++ b/docs/v1/data-initialization.md
@@ -2,38 +2,40 @@
 
 DocumentDB supports two initialization modes when the emulator container starts:
 
-* Built-in sample data for quick exploration (enabled by default)
+* Built-in sample data for quick exploration (disabled by default, opt-in)
 * Custom JavaScript initialization scripts supplied by the user
 
 ## Environment Variables
 
 The entrypoint honors the following environment variables:
 
+- `INIT_DATA`: Set to `true` to load built-in sample data (default: `false`).
 - `INIT_DATA_PATH`: Directory containing `.js` initialization files (default: `/init_doc_db.d`).
-- `SKIP_INIT_DATA`: Set to `true` to skip loading built-in sample data (default: `false`).
+- `SKIP_INIT_DATA`: Legacy alias for disabling built-in sample data.
 
-> Note: When custom initialization is requested with `--init-data-path`, the entrypoint internally sets `SKIP_INIT_DATA=true` so that only the provided scripts run.
+> Note: Custom initialization via `--init-data-path` is independent of `INIT_DATA`; custom scripts run whenever the directory exists and contains `.js` files.
 
 ## Command Line Options
 
+- `--init-data [true|false]`: Enable or disable loading the built-in sample collections.
 - `--init-data-path [PATH]`: Execute all `.js` files in the specified directory (alphabetical order) using `mongosh`.
-- `--skip-init-data`: Skip loading the built-in sample collections.
+- `--skip-init-data`: Legacy alias for `--init-data false`.
 
-If no option is supplied, the emulator starts with the built-in sample data.
+If no option is supplied, the emulator starts without built-in sample data.
 
 ## Usage Examples
 
-### Default startup (built-in sample data)
+### Default startup (no initialization data)
 ```bash
 docker run -p 10260:10260 -p 9712:9712 \
   --password mypassword \
   documentdb/local
 ```
 
-### Skip sample data entirely
+### Start with built-in sample data
 ```bash
 docker run -p 10260:10260 -p 9712:9712 \
-  --skip-init-data \
+  --init-data true \
   --password mypassword \
   documentdb/local
 ```
@@ -51,7 +53,7 @@ docker run -p 10260:10260 -p 9712:9712 \
 ```bash
 docker run -p 10260:10260 -p 9712:9712 \
   -e INIT_DATA_PATH=/custom/init/path \
-  -e SKIP_INIT_DATA=true \
+  -e INIT_DATA=false \
   -e PASSWORD=mypassword \
   -v /path/to/your/init/scripts:/custom/init/path \
   documentdb/local
@@ -59,7 +61,7 @@ docker run -p 10260:10260 -p 9712:9712 \
 
 ## Built-in Sample Data
 
-Unless `--skip-init-data` (or `SKIP_INIT_DATA=true`) is supplied, the following collections are created in the `sampledb` database:
+When `--init-data true` (or `INIT_DATA=true`) is supplied, the following collections are created in the `sampledb` database:
 - users (5 sample users)
 - products (5 sample products)
 - orders (4 sample orders)
@@ -67,4 +69,4 @@ Unless `--skip-init-data` (or `SKIP_INIT_DATA=true`) is supplied, the following 
 
 ## Security Note
 
-Built-in sample data is intended for evaluation scenarios. Disable it via `--skip-init-data` / `SKIP_INIT_DATA=true` and provide vetted scripts through `INIT_DATA_PATH` for production workloads.
+Built-in sample data is intended for evaluation scenarios. Keep it disabled by default for production-style startup paths, and enable it only with `--init-data true` / `INIT_DATA=true` when you want the demo dataset.

--- a/docs/v1/index.md
+++ b/docs/v1/index.md
@@ -63,6 +63,9 @@ To run the prebuild image with the DocumentDB Gateway, use the following command
 ```bash
 docker run -dt -p 10260:10260 -e USERNAME=<username> -e PASSWORD=<password> ghcr.io/microsoft/documentdb/documentdb-local:latest
 
+# Add demo data only when you want the built-in sample dataset
+docker run -dt -p 10260:10260 -e USERNAME=<username> -e PASSWORD=<password> -e INIT_DATA=true ghcr.io/microsoft/documentdb/documentdb-local:latest
+
 mongosh localhost:10260 -u <username> -p <password> \
         --authenticationMechanism SCRAM-SHA-256 \
         --tls \

--- a/packaging/test_packages/test-gateway-install-entrypoint.sh
+++ b/packaging/test_packages/test-gateway-install-entrypoint.sh
@@ -6,7 +6,7 @@ python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
 pip install pymongo
 
-nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username cloudsa --password 123456 --skip-init-data > emulator.log 2>&1 &
+nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username cloudsa --password 123456 > emulator.log 2>&1 &
 # Give some time for the emulator to start
 while ! grep -q "=== DocumentDB is ready ===" emulator.log; do
     sleep 1

--- a/sample-data/01-users.js
+++ b/sample-data/01-users.js
@@ -98,12 +98,15 @@ db.users.insertMany([
     }
 ]);
 
-print("Created " + db.users.countDocuments() + " users in the users collection");
-
 // Create indexes for better query performance
-db.users.createIndex({ "email": 1 }, { unique: true });
-db.users.createIndex({ "username": 1 }, { unique: true });
-db.users.createIndex({ "city": 1 });
-db.users.createIndex({ "tags": 1 });
+db.runCommand({
+    createIndexes: "users",
+    indexes: [
+        { key: { "email": 1 }, name: "email_1", unique: true },
+        { key: { "username": 1 }, name: "username_1", unique: true },
+        { key: { "city": 1 }, name: "city_1" },
+        { key: { "tags": 1 }, name: "tags_1" }
+    ]
+});
 
 print("Created indexes on users collection");

--- a/sample-data/02-products.js
+++ b/sample-data/02-products.js
@@ -135,13 +135,16 @@ db.products.insertMany([
     }
 ]);
 
-print("Created " + db.products.countDocuments() + " products in the products collection");
-
 // Create indexes for better query performance
-db.products.createIndex({ "category": 1 });
-db.products.createIndex({ "brand": 1 });
-db.products.createIndex({ "price": 1 });
-db.products.createIndex({ "tags": 1 });
-db.products.createIndex({ "sku": 1 }, { unique: true });
+db.runCommand({
+    createIndexes: "products",
+    indexes: [
+        { key: { "category": 1 }, name: "category_1" },
+        { key: { "brand": 1 }, name: "brand_1" },
+        { key: { "price": 1 }, name: "price_1" },
+        { key: { "tags": 1 }, name: "tags_1" },
+        { key: { "sku": 1 }, name: "sku_1", unique: true }
+    ]
+});
 
 print("Created indexes on products collection");

--- a/sample-data/03-orders.js
+++ b/sample-data/03-orders.js
@@ -165,13 +165,16 @@ db.orders.insertMany([
     }
 ]);
 
-print("Created " + db.orders.countDocuments() + " orders in the orders collection");
-
 // Create indexes for better query performance
-db.orders.createIndex({ "userId": 1 });
-db.orders.createIndex({ "orderNumber": 1 }, { unique: true });
-db.orders.createIndex({ "status": 1 });
-db.orders.createIndex({ "orderDate": 1 });
-db.orders.createIndex({ "customerInfo.email": 1 });
+db.runCommand({
+    createIndexes: "orders",
+    indexes: [
+        { key: { "userId": 1 }, name: "userId_1" },
+        { key: { "orderNumber": 1 }, name: "orderNumber_1", unique: true },
+        { key: { "status": 1 }, name: "status_1" },
+        { key: { "orderDate": 1 }, name: "orderDate_1" },
+        { key: { "customerInfo.email": 1 }, name: "customerInfo.email_1" }
+    ]
+});
 
 print("Created indexes on orders collection");

--- a/sample-data/04-analytics.js
+++ b/sample-data/04-analytics.js
@@ -57,32 +57,14 @@ db.analytics.insertMany([
     }
 ]);
 
-print("Created " + db.analytics.countDocuments() + " analytics records");
-
 // Create indexes for analytics queries
-db.analytics.createIndex({ "period": 1 });
-db.analytics.createIndex({ "type": 1 });
-db.analytics.createIndex({ "date": 1 });
+db.runCommand({
+    createIndexes: "analytics",
+    indexes: [
+        { key: { "period": 1 }, name: "period_1" },
+        { key: { "type": 1 }, name: "type_1" },
+        { key: { "date": 1 }, name: "date_1" }
+    ]
+});
 
 print("Created indexes on analytics collection");
-
-// Create some aggregation views for common queries
-print("Setting up sample aggregation examples...");
-
-// Example aggregation: User order summary
-print("Sample aggregation - User order summary:");
-db.orders.aggregate([
-    {
-        $group: {
-            _id: "$userId",
-            totalOrders: { $sum: 1 },
-            totalSpent: { $sum: "$orderSummary.total" },
-            averageOrderValue: { $avg: "$orderSummary.total" }
-        }
-    },
-    {
-        $sort: { totalSpent: -1 }
-    }
-]).forEach(printjson);
-
-print("Sample data initialization completed!");

--- a/sample-data/README.md
+++ b/sample-data/README.md
@@ -39,7 +39,7 @@ All sample data is inserted into the `sampledb` database to keep it separate fro
 
 ## Usage
 
-These files are automatically executed when the DocumentDB container starts (unless `--skip-init-data` or `SKIP_INIT_DATA=true` is supplied). They can also be run manually using mongosh:
+These files are executed when the DocumentDB container starts only if built-in sample data is explicitly enabled with `--init-data true` or `INIT_DATA=true`. They can also be run manually using mongosh:
 
 ```bash
 mongosh localhost:10260 -u username -p mypassword --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --file 01-users.js

--- a/sample-data/README.md
+++ b/sample-data/README.md
@@ -31,7 +31,7 @@ Contains sample analytics and reporting data:
 - Monthly summary metrics
 - Daily user activity logs
 - Product performance data
-- Sample aggregation examples
+- Fields that can be queried with aggregation pipelines after startup
 
 ## Database Structure
 

--- a/scripts/emulator_entrypoint.sh
+++ b/scripts/emulator_entrypoint.sh
@@ -97,14 +97,17 @@ Optional arguments:
                         Allow external connections to PostgreSQL.
                         Defaults to false.
                         Overrides ALLOW_EXTERNAL_CONNECTIONS environment variable.
+  --init-data [true|false]
+                        Enable initialization with built-in sample data.
+                        Defaults to false.
+                        Overrides INIT_DATA environment variable.
   --init-data-path [PATH]
                         Specify a directory containing JavaScript files for database initialization.
                         Files will be executed in alphabetical order using mongosh.
-                        When this option is used, built-in sample data is automatically disabled.
                         Defaults to /init_doc_db.d
                         Overrides INIT_DATA_PATH environment variable.
   --skip-init-data      Skip initialization with built-in sample data.
-                        By default, sample collections (users, products, orders, analytics) in 'sampledb' database will be created.
+                        Legacy alias for --init-data false.
                         Overrides SKIP_INIT_DATA environment variable.
   --disable-extended-rum
                         Disable the use of extended_rum for indexes.
@@ -196,13 +199,18 @@ do
         export ALLOW_EXTERNAL_CONNECTIONS=$1
         shift;;
 
+    --init-data)
+        shift
+        export INIT_DATA=$1
+        shift;;
+
     --init-data-path)
         shift
         export INIT_DATA_PATH=$1
-        export SKIP_INIT_DATA=true  # Disable built-in sample data when custom path is provided
         shift;;
 
     --skip-init-data)
+        export INIT_DATA=false
         export SKIP_INIT_DATA=true
         shift;;
 
@@ -225,8 +233,9 @@ export USERNAME=${USERNAME:-default_user}
 export PASSWORD=${PASSWORD:-Admin100}
 export CREATE_USER=${CREATE_USER:-true}
 export START_POSTGRESQL=${START_POSTGRESQL:-true}
+export INIT_DATA=${INIT_DATA:-}
 export INIT_DATA_PATH=${INIT_DATA_PATH:-/init_doc_db.d}
-export SKIP_INIT_DATA=${SKIP_INIT_DATA:-false}
+export SKIP_INIT_DATA=${SKIP_INIT_DATA:-}
 export DISABLE_EXTENDED_RUM=${DISABLE_EXTENDED_RUM:-false}
 
 # Setup centralized log directory structure
@@ -293,11 +302,32 @@ if [ -n "$LOG_LEVEL" ] && \
     exit 1
 fi
 
+if [ -n "$INIT_DATA" ] && \
+   [ "$INIT_DATA" != "true" ] && \
+   [ "$INIT_DATA" != "false" ]; then
+    echo "Invalid init-data value $INIT_DATA, must be true or false"
+    exit 1
+fi
+
 if [ -n "$SKIP_INIT_DATA" ] && \
    [ "$SKIP_INIT_DATA" != "true" ] && \
    [ "$SKIP_INIT_DATA" != "false" ]; then
     echo "Invalid skip-init-data value $SKIP_INIT_DATA, must be true or false"
     exit 1
+fi
+
+if [ -z "$INIT_DATA" ]; then
+    if [ "$SKIP_INIT_DATA" = "false" ]; then
+        export INIT_DATA=true
+    else
+        export INIT_DATA=false
+    fi
+fi
+
+if [ "$INIT_DATA" = "true" ]; then
+    export SKIP_INIT_DATA=false
+else
+    export SKIP_INIT_DATA=true
 fi
 
 if [ "$START_POSTGRESQL" = "true" ]; then
@@ -465,8 +495,8 @@ if [ -d "$INIT_DATA_PATH" ] && [ "$(ls -A "$INIT_DATA_PATH"/*.js 2>/dev/null)" ]
     fi
 fi
 
-# Initialize database with sample data if enabled (default behavior unless --skip-init-data is specified)
-if [ "$SKIP_INIT_DATA" != "true" ]; then
+# Initialize database with sample data if explicitly enabled
+if [ "$INIT_DATA" = "true" ]; then
     echo "Initializing database with built-in sample data..."
     
     # Use the sample data directory
@@ -500,9 +530,9 @@ if [ "$SKIP_INIT_DATA" != "true" ]; then
     fi
 fi
 
-if [ "$custom_data_initialized" = "false" ] && [ "$SKIP_INIT_DATA" = "true" ]; then
-    echo "No initialization data loaded (--skip-init-data was specified)."
-    echo "To load data: use --init-data-path [PATH] for custom data, or remove --skip-init-data for built-in sample data."
+if [ "$custom_data_initialized" = "false" ] && [ "$INIT_DATA" != "true" ]; then
+    echo "No initialization data loaded."
+    echo "To load data: use --init-data true for built-in sample data, or --init-data-path [PATH] for custom data."
 fi
 # Also stream existing gateway logs (for historical logs that might already exist)
 if [ -f "$GATEWAY_LOG" ]; then

--- a/test-init-data/test_init_data.sh
+++ b/test-init-data/test_init_data.sh
@@ -5,7 +5,7 @@ set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 CONTAINER_NAME="documentdb-gateway-test"
 IMAGE_NAME="documentdb-gateway-test"

--- a/test-init-data/test_init_invalid_data.sh
+++ b/test-init-data/test_init_invalid_data.sh
@@ -7,7 +7,7 @@ set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Test configuration
 CONTAINER_NAME="documentdb-invalid-init-test"

--- a/test-init-data/test_init_sample_data.sh
+++ b/test-init-data/test_init_sample_data.sh
@@ -5,7 +5,7 @@ set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 CONTAINER_NAME="documentdb-init-data-test"
 IMAGE_NAME="documentdb-init-data-test"
@@ -228,6 +228,30 @@ verify_sample_data() {
     export SEATTLE_USERS ELECTRONICS_PRODUCTS DELIVERED_ORDERS PREMIUM_USERS
 }
 
+# Function to verify sample data is not loaded by default
+verify_sample_data_disabled_by_default() {
+    echo "=== Verifying Built-in Sample Data Is Disabled By Default ==="
+
+    DB_LIST=$(mongosh localhost:$DOCUMENTDB_PORT -u default_user -p $PASSWORD --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --eval "db.adminCommand('listDatabases')" --quiet 2>/dev/null)
+
+    if [[ "$DB_LIST" == *"sampledb"* ]]; then
+        echo "❌ sampledb database found unexpectedly"
+        echo "Available databases:"
+        echo "$DB_LIST"
+        return 1
+    fi
+
+    echo "✅ sampledb database not found"
+
+    if docker logs $CONTAINER_NAME 2>&1 | grep -q "Initializing database with built-in sample data"; then
+        echo "❌ Built-in sample data initialization ran unexpectedly"
+        return 1
+    fi
+
+    echo "✅ Built-in sample data initialization did not run"
+    return 0
+}
+
 # Function to test environment variable usage
 test_environment_variable() {
     echo
@@ -319,8 +343,37 @@ main() {
     # Build the Docker image
     build_image
     
-    # Test 1: Command line flag --init-data=true
-    echo "=== Test 1: Command Line Flag (--init-data true) ==="
+    # Test 1: Default startup should not load sample data
+    echo "=== Test 1: Default Startup (no sample data) ==="
+    echo "Starting DocumentDB container without built-in sample data..."
+    docker run -d \
+        --name $CONTAINER_NAME \
+        -p $DOCUMENTDB_PORT:10260 \
+        -e PASSWORD=$PASSWORD \
+        $IMAGE_NAME \
+        --password $PASSWORD
+
+    echo "Container started with ID: $(docker ps -q -f name=$CONTAINER_NAME)"
+    echo
+
+    if wait_for_documentdb; then
+        if verify_sample_data_disabled_by_default; then
+            echo "✅ Default startup verification completed"
+            DEFAULT_OFF_RESULT=0
+        else
+            echo "❌ Default startup verification failed"
+            return 1
+        fi
+    else
+        echo "❌ Default startup failed"
+        docker logs $CONTAINER_NAME
+        return 1
+    fi
+
+    cleanup
+
+    # Test 2: Command line flag --init-data true
+    echo "=== Test 2: Command Line Flag (--init-data true) ==="
     echo "Starting DocumentDB container with --init-data true..."
     docker run -d \
         --name $CONTAINER_NAME \
@@ -351,7 +404,7 @@ main() {
             return 1
         fi
         
-        # Test 2: Environment variable
+        # Test 3: Environment variable
         test_environment_variable
         ENV_TEST_RESULT=$?
         
@@ -359,6 +412,7 @@ main() {
         echo "=== Test Results Summary ==="
         
         # Expected values based on our sample data
+        EXPECTED_DEFAULT_OFF="PASS"
         EXPECTED_USERS=5
         EXPECTED_PRODUCTS=5
         EXPECTED_ORDERS=4
@@ -375,6 +429,7 @@ main() {
         MIN_ANALYTICS_INDEXES=4  # _id + period + type + date
         
         # Test results
+        DEFAULT_OFF_PASS=$([[ "$DEFAULT_OFF_RESULT" == "0" ]] && echo "✅" || echo "❌")
         USERS_PASS=$([[ "$USER_COUNT" == "$EXPECTED_USERS" ]] && echo "✅" || echo "❌")
         PRODUCTS_PASS=$([[ "$PRODUCT_COUNT" == "$EXPECTED_PRODUCTS" ]] && echo "✅" || echo "❌")
         ORDERS_PASS=$([[ "$ORDER_COUNT" == "$EXPECTED_ORDERS" ]] && echo "✅" || echo "❌")
@@ -392,6 +447,7 @@ main() {
         echo "┌─────────────────────────────────┬──────────┬──────────┬────────┐"
         echo "│ Test Case                       │ Expected │ Actual   │ Result │"
         echo "├─────────────────────────────────┼──────────┼──────────┼────────┤"
+        echo "│ Default Startup                 │ $EXPECTED_DEFAULT_OFF     │ $([ "$DEFAULT_OFF_RESULT" = "0" ] && echo "PASS" || echo "FAIL")     │ $DEFAULT_OFF_PASS     │"
         echo "│ Users Collection                │ $EXPECTED_USERS        │ $USER_COUNT        │ $USERS_PASS     │"
         echo "│ Products Collection             │ $EXPECTED_PRODUCTS        │ $PRODUCT_COUNT        │ $PRODUCTS_PASS     │"
         echo "│ Orders Collection               │ $EXPECTED_ORDERS        │ $ORDER_COUNT        │ $ORDERS_PASS     │"
@@ -412,6 +468,7 @@ main() {
         ALL_TESTS_PASSED=true
         
         # Check all conditions
+        [ "$DEFAULT_OFF_RESULT" != "0" ] && ALL_TESTS_PASSED=false
         [ "$USER_COUNT" != "$EXPECTED_USERS" ] && ALL_TESTS_PASSED=false
         [ "$PRODUCT_COUNT" != "$EXPECTED_PRODUCTS" ] && ALL_TESTS_PASSED=false
         [ "$ORDER_COUNT" != "$EXPECTED_ORDERS" ] && ALL_TESTS_PASSED=false
@@ -430,6 +487,7 @@ main() {
             echo "🎉 OVERALL RESULT: SUCCESS! All tests passed."
             echo "✅ Docker build completed successfully"
             echo "✅ Container started and initialized properly"
+            echo "✅ Default startup does not load built-in sample data"
             echo "✅ All sample collections created with expected data"
             echo "✅ All indexes created successfully"
             echo "✅ All queries work as expected"


### PR DESCRIPTION
Fixes #480

## Summary
Improve the default `documentdb-local` startup path when built-in sample data is enabled.

- Batch index creation in each sample-data script with a single `createIndexes` command per collection.
- Remove extra startup-time work that does not change the seeded dataset, including `countDocuments()` logging and the sample analytics aggregation demo.
- Update the sample-data README to clarify that aggregation examples can still be run after startup instead of during initialization.

## Why
The sample-data initialization path runs during startup, so every extra command delays readiness for local development. The previous scripts issued multiple per-index commands and ran additional demo queries after loading data. This change keeps the same sample collections and indexes while reducing unnecessary startup work.

## Impact
- Faster readiness for the default sample-data startup flow.
- No change to the documents or indexes that get seeded.
- No change to how aggregation queries can be used after startup.
