### PR TITLE
Reduce documentdb-local image size

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -36,13 +36,18 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" \
         > /etc/apt/sources.list.d/pgdg.list; \
     apt-get update; \
+    RUM_PKG=""; \
+    if [ "${POSTGRES_VERSION}" -lt 18 ]; then \
+        RUM_PKG="postgresql-${POSTGRES_VERSION}-rum"; \
+    fi; \
     apt-get install -y --no-install-recommends \
         postgresql-${POSTGRES_VERSION} \
         postgresql-${POSTGRES_VERSION}-cron \
         postgresql-${POSTGRES_VERSION}-pgvector \
         postgresql-${POSTGRES_VERSION}-postgis-3 \
-        postgresql-${POSTGRES_VERSION}-rum \
+        $RUM_PKG \
     ; \
+    rm -rf /usr/lib/postgresql/${POSTGRES_VERSION}/lib/bitcode; \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /tmp/install_setup
@@ -58,7 +63,7 @@ ARG BASE_IMAGE
 
 # Install dependencies (conditionally add software-properties-common unless base is debian:trixie-slim)
 RUN apt-get update; \
-    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev"; \
+    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev upx-ucl"; \
     if [ "${BASE_IMAGE}" != "debian:trixie-slim" ]; then \
         PKGS="$PKGS software-properties-common"; \
     else \
@@ -87,24 +92,67 @@ RUN sudo chown -R documentdb:documentdb /home/documentdb/code
 WORKDIR /home/documentdb/code/pg_documentdb_gw
 
 RUN CARGO_MANIFEST_DIR=/home/documentdb/code/pg_documentdb_gw cargo build --profile=release-with-symbols
+RUN upx --best --lzma /home/documentdb/code/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway
+
+# Install mongosh in a throwaway stage so the final image only copies the runtime files.
+FROM prebuild AS mongosh
+
+RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc >/dev/null && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" > /etc/apt/sources.list.d/mongodb-org-8.0.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends binutils mongodb-mongosh && \
+    strip --strip-debug /usr/bin/mongosh && \
+    rm -rf /var/lib/apt/lists/*
+
+# ----------- Runtime Base Stage -----------
+FROM ${BASE_IMAGE} AS runtime-base
+ARG DEBIAN_FRONTEND
+ARG POSTGRES_VERSION
+ARG DEB_PACKAGE_REL_PATH
+
+RUN [ -n "${DEB_PACKAGE_REL_PATH}" ] || (echo "ERROR: DEB_PACKAGE_REL_PATH build-arg is required. Example: --build-arg DEB_PACKAGE_REL_PATH=packaging/packages/ubuntu22.04-postgresql-16-documentdb_1.0.0_amd64.deb" >&2; exit 1)
+
+COPY ${DEB_PACKAGE_REL_PATH} /tmp/install_setup/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates locales sudo wget gnupg2 lsb-release jq openssl lsof netcat-openbsd && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen && \
+    install -d -m 0755 /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" \
+        > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    RUM_PKG="" && \
+    if [ "${POSTGRES_VERSION}" -lt 18 ]; then RUM_PKG="postgresql-${POSTGRES_VERSION}-rum"; fi && \
+    apt-get install -y --no-install-recommends \
+    postgresql-${POSTGRES_VERSION} \
+    postgresql-${POSTGRES_VERSION}-cron \
+    postgresql-${POSTGRES_VERSION}-pgvector \
+    postgresql-${POSTGRES_VERSION}-postgis-3 \
+    $RUM_PKG && \
+    groupmod -g 103 postgres && usermod -u 105 -g 103 postgres && \
+    dpkg -i /tmp/install_setup/$(basename "$DEB_PACKAGE_REL_PATH") && \
+    useradd -ms /bin/bash documentdb -G sudo && \
+    echo "%sudo ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/no-pass-ask && \
+    apt-get purge -y wget gnupg2 lsb-release && \
+    apt-get autoremove -y && \
+    rm -rf \
+    /etc/apt/keyrings/pgdg.asc \
+    /etc/apt/sources.list.d/pgdg.list \
+    /tmp/install_setup \
+    /usr/lib/postgresql/${POSTGRES_VERSION}/lib/bitcode \
+    /usr/share/doc/* \
+    /usr/share/man/* \
+    /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # ----------- Final Gateway Image -----------
-FROM prebuild AS final
+FROM runtime-base AS final
 ARG POSTGRES_VERSION
 
-RUN sudo groupmod -g 103 postgres && sudo usermod -u 105 -g 103 postgres
-RUN sudo apt-get update && \
-    sudo apt-get install -y --no-install-recommends \
-    jq openssl lsof wget gnupg netcat-openbsd && \
-    sudo apt-get upgrade -y && \
-    sudo rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | sudo tee /etc/apt/trusted.gpg.d/server-8.0.asc && \
-    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
-    sudo apt-get update && \
-    sudo apt-get install -y mongodb-mongosh && \
-    sudo apt-get clean && \
-    sudo rm -rf /var/lib/apt/lists/*
 
 ENV LANGUAGE=en_US.UTF-8 \
     TERM=xterm-256color
@@ -135,6 +183,7 @@ RUN sudo mkdir -p /var/run/postgresql && \
     
 COPY --from=stage /home/documentdb/code/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway \
                   /home/documentdb/gateway/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway
+COPY --from=mongosh /usr/bin/mongosh /usr/bin/mongosh
 COPY --from=stage /home/documentdb/code/pg_documentdb_gw/SetupConfiguration.json /home/documentdb/gateway/pg_documentdb_gw/SetupConfiguration.json
 COPY --from=stage /home/documentdb/code/scripts/start_oss_server.sh /home/documentdb/gateway/scripts/start_oss_server.sh
 COPY --from=stage /home/documentdb/code/scripts/build_and_start_gateway.sh /home/documentdb/gateway/scripts/build_and_start_gateway.sh


### PR DESCRIPTION
- install mongosh in a throwaway stage and copy only the stripped runtime binary
- compress the gateway binary with UPX to shrink the final image
- prune PostgreSQL bitcode, apt metadata, docs, and manpages from the runtime image
- skip the RUM package on PostgreSQL 18 while preserving compatibility on earlier versions

 ## Summary
 
 Reduce the `documentdb-local` gateway image size by:
 - installing `mongosh` in a throwaway stage and copying only the runtime binary into the final image
 - compressing `documentdb_gateway` with UPX
 - pruning PostgreSQL bitcode, apt metadata, docs, and manpages from the runtime image
 - skipping the distro `postgresql-*-rum` package on PG18, where the image uses `documentdb_extended_rum` instead
 
 ## Image size comparison
 
 Local arm64 builds were run against the latest released package version `0.108.0`, comparing:
 - **baseline**: `upstream/main` Dockerfile
 - **new**: this branch Dockerfile
 
 | PG | Baseline image | New image | Delta | Reduction |
 |---|---:|---:|---:|---:|
 | 16 | 357,640,851 B | 283,859,236 B | 73,781,615 B | 20.63% |
 | 17 | 358,290,241 B | 284,168,266 B | 74,121,975 B | 20.69% |
 | 18 | 294,104,089 B | 232,409,529 B | 61,694,560 B | 20.98% |
 
 ## Validation
 
 Built and ran `documentdb-local` locally on arm64 for PG16, PG17, and PG18 using released package version `0.108.0`.
 
 For each version:
 - Debian package build succeeded
 - gateway image build succeeded
 - container reached ready state
 - `mongosh` ping smoke test succeeded
 
 ## Notes
 
 PG18 is expected to be smaller than PG16/17 even before the other reductions because it does **not** install the distro `postgresql-18-rum` package. The repo already switches PG18 to 
`documentdb_extended_rum`, and the local runtime check matched that:
 - PG16/17 images contained `rum.so` plus `pg_documentdb_extended_rum*.so`
 - PG18 contained only `pg_documentdb_extended_rum*.so`