### PR TITLE
Honor custom documentdb-local startup credentials

### DIFF
--- a/packaging/test_packages/test-gateway-install-entrypoint.sh
+++ b/packaging/test_packages/test-gateway-install-entrypoint.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 set -e
 
-
-USERNAME="docdb_admin"
-PASSWORD="123456"
-
 python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
 pip install pymongo
 
-nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username "$USERNAME" --password "$PASSWORD" --skip-init-data > emulator.log 2>&1 &
+nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username docdb_admin --password 123456 --skip-init-data > emulator.log 2>&1 &
 # Give some time for the emulator to start
 while ! grep -q "=== DocumentDB is ready ===" emulator.log; do
     sleep 1
 done
 
 echo "Gateway is ready, proceeding with next steps..."
-python test_gateway.py --username "$USERNAME" --password "$PASSWORD"
+python test_gateway.py --username docdb_admin --password 123456

--- a/packaging/test_packages/test-gateway-install-entrypoint.sh
+++ b/packaging/test_packages/test-gateway-install-entrypoint.sh
@@ -2,15 +2,18 @@
 set -e
 
 
+USERNAME="docdb_admin"
+PASSWORD="123456"
+
 python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
 pip install pymongo
 
-nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username cloudsa --password 123456 --skip-init-data > emulator.log 2>&1 &
+nohup /home/documentdb/gateway/scripts/emulator_entrypoint.sh --username "$USERNAME" --password "$PASSWORD" --skip-init-data > emulator.log 2>&1 &
 # Give some time for the emulator to start
 while ! grep -q "=== DocumentDB is ready ===" emulator.log; do
     sleep 1
 done
 
 echo "Gateway is ready, proceeding with next steps..."
-python test_gateway.py --username cloudsa --password 123456
+python test_gateway.py --username "$USERNAME" --password "$PASSWORD"

--- a/scripts/emulator_entrypoint.sh
+++ b/scripts/emulator_entrypoint.sh
@@ -328,7 +328,21 @@ if [ "$START_POSTGRESQL" = "true" ]; then
     if [ "$DISABLE_EXTENDED_RUM" = "true" ]; then
         EXTENDED_RUM_FLAG=""
     fi
-    /home/documentdb/gateway/scripts/start_oss_server.sh $EXTENDED_RUM_FLAG $PGOPTIONS -d $DATA_PATH -p $POSTGRESQL_PORT | tee -a "$OSS_SERVER_LOG"
+    start_oss_server_args=()
+    if [ -n "$EXTENDED_RUM_FLAG" ]; then
+        start_oss_server_args+=("$EXTENDED_RUM_FLAG")
+    fi
+    if [ -n "${PGOPTIONS:-}" ]; then
+        start_oss_server_args+=("$PGOPTIONS")
+    fi
+    if [ "$CREATE_USER" = "false" ]; then
+        start_oss_server_args+=(-u "")
+    else
+        start_oss_server_args+=(-u "$USERNAME" -a "$PASSWORD")
+    fi
+    start_oss_server_args+=(-d "$DATA_PATH" -p "$POSTGRESQL_PORT")
+
+    /home/documentdb/gateway/scripts/start_oss_server.sh "${start_oss_server_args[@]}" | tee -a "$OSS_SERVER_LOG"
 
     echo "OSS server started."
     echo "[ENTRYPOINT] Setting up PostgreSQL log streaming..."


### PR DESCRIPTION
## Summary
- pass the requested username and password into the initial `start_oss_server.sh` path so fresh data directories create the caller-provided admin user instead of falling back to `docdb_admin/Admin100`
- prevent a hidden default `docdb_admin/Admin100` account from being created when `documentdb-local` starts with a different custom username
- preserve existing restart semantics by leaving the existing-user path unchanged
- tighten the package smoke test to cover the `docdb_admin` + custom password startup path

## Validation
- built a local `documentdb-local` image from the current workspace
- verified a fresh start with `docdb_admin/FreshPass123` succeeds
- verified `docdb_admin/Admin100` fails on that fresh start
- verified a fresh start with `cloudsa/CustomPass123` succeeds
- verified `docdb_admin/Admin100` fails in that `cloudsa` startup scenario