### PR TITLE
Fix Docker command order in README Step 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Step 3. Setup DocumentDB using Docker
 
 ```bash
 
+   # Remove any existing DocumentDB image
+   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest || echo "No existing documentdb image to remove"
+
    # Pull the latest DocumentDB Docker image
    docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
 
@@ -64,7 +67,6 @@ Step 3. Setup DocumentDB using Docker
 
    # Run the container with your chosen username and password
    docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
-   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest || echo "No existing documentdb image to remove"
 
 ```
 


### PR DESCRIPTION
## Summary
- Moved the `docker image rm` cleanup command before `docker pull` in the README **Get Started > Step 3** section, so old images are removed before pulling a fresh copy.

## Details
The cleanup command was previously placed after `docker run`, which meant users would run the new container and then remove the image — the wrong logical order. The corrected order is:

1. `docker image rm` (cleanup old image if exists)
2. `docker pull` (pull latest image)
3. `docker tag` (tag for convenience)
4. `docker run` (start the container)

Fixes #441